### PR TITLE
sec(tls): disable renegotiation

### DIFF
--- a/src/connections/tls.c
+++ b/src/connections/tls.c
@@ -215,7 +215,7 @@ SSL_CTX* TLS_CTX_new(OPTIONAL SSL_CTX* ssl_ctx,
                            /* Do not allow outdated SSl/TLS protocol versions: */
                            bitor SSL_OP_NO_SSLv2 bitor SSL_OP_NO_SSLv3 bitor SSL_OP_NO_TLSv1 bitor SSL_OP_NO_TLSv1_1
                            bitor SSL_OP_NO_COMPRESSION
-                           /* Disable TLS Renegotiation
+                           /* Disable TLS Renegotiation */
                            bitor SSL_OP_NO_RENEGOTIATION
                            bitor (long)
 #endif


### PR DESCRIPTION
Disable TLS 1.2 renegotiation to work around CVE-2021-3449