### PR TITLE
`crl_mgmt.c`: fix mem leak on `out` BIO in `put_crl_into_cache()`

### DIFF
--- a/src/certstatus/crl_mgmt.c
+++ b/src/certstatus/crl_mgmt.c
@@ -185,6 +185,7 @@ static int put_crl_into_cache(X509_CRL * crl, const char * cachefile)
         if (!res) {
             BIO_printf(bio_err, "unable to write CRL\n");
         }
+        BIO_free(out);
     }
 
     return res;


### PR DESCRIPTION
This fixes a mem leak reported by a user.