### PR TITLE
debian/control: fix Debian package dependency on openssl vs. libssl

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Homepage: https://github.com/siemens/libsecutils
 
 Package: libsecutils
 Architecture: any
-Depends: libssl, libuta
+Depends: openssl, libuta
 Build-Depends: libssl-dev
 Description: OpenSSL wrapper library
  OpenSSL wrapper library for easy re-use of commonly needen functionality


### PR DESCRIPTION
I've been able to successfully build the Debian packages `libsecutils` and `libsecutils-dev` as described in the `README.md`.
Yet when trying to install them on a Debian 10 system, I got a missing dependency on `libssl`.
My system has `libssl-dev` installed, and AFAICS the corresponding binary package is called `openssl` rather than `libssl`.
So this PR changes the respective entry in `debian/control` accordingly.