### PR TITLE
Debian packaging fixups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.a
 *.o
 *.so
+*.so.*
 *.pdf
 *.log
 *.bak
@@ -23,5 +24,7 @@ debian/.debhelper
 debian/debhelper-build-stamp
 debian/files
 debian/tmp
-debian/libsecutils{,-dev,-bins}
+debian/libsecutils
+debian/libsecutils-dev
+debian/libsecutils-bins
 debian/*.substvars

--- a/Makefile
+++ b/Makefile
@@ -181,12 +181,11 @@ $(BUILDDIR):
 $(OBJS): | $(BUILDDIR)
 
 deb:
-ifeq ($(SECUTILS_CONFIG_USE_ICV)$(SECUTILS_USE_UTA),)
-#	debuild unfortunately does not pass environment variables
-	debuild -uc -us --lintian-opts --profile debian # --fail-on none
-else
-	dpkg-buildpackage -uc -us # may prepend DH_VERBOSE=1
-endif
+	debuild --preserve-envvar SECUTILS_CONFIG_USE_ICV \
+	  --preserve-envvar SECUTILS_USE_UTA -uc -us \
+	  --lintian-opts --profile debian # --fail-on none
+# alternative:
+#	LD_LIBRARY_PATH= dpkg-buildpackage -uc -us # may prepend DH_VERBOSE=1
 
 clean_deb:
 	rm -rf debian/tmp debian/libsecutils{,-dev,-bins}

--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ This repository can build the following Debian packages.
 
 * `libsecutils` - the shared library
 * `libsecutils-dev` - development headers
-* `libsecutils-bins` - helper binaries from `util/` - so far, there is only `icvutil`,
-   and this is present only if `SECUTILS_USE_UTA` is defined
+* `libsecutils-bins` - helper binaries from `util/` - so far, there is only `icvutil`
 
 To build the Debian packages, the following dependencies need to be installed:
+* `debhelper`
 * `libssl-dev`
 * `libuta-dev` (from [github.com/siemens/libuta](https://github.com/siemens/libuta))
    if `SECUTILS_USE_UTA` is defined

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,7 +1,11 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: libsecutils
-Upstream-Contact: David von Oheimb <david.von.oheimb@siemens.com>
+Upstream-Contact: David von Oheimb <David.von.Oheimb@siemens.com>
 
 Files: *
 Copyright: 2021 Siemens Mobility AG
 License: Apache-2.0
+ Licensed under the Apache License 2.0 (the "License").
+ You may not use this file except in compliance with the License.
+ On Debian systems, the full text of the Apache-2.0 license
+ can be found in the file '/usr/share/common-licenses/Apache-2.0'.


### PR DESCRIPTION
* `debian/` and `.gitignore`: Clean up Debian packaging, avoiding further `lintian` warning
* `README.md`: minor improvements on dependencies stated