### PR TITLE
UTIL_parse_name(): allow empty input string for NULL-DN

### DIFF
--- a/include/secutils/credentials/cert.h
+++ b/include/secutils/credentials/cert.h
@@ -102,7 +102,8 @@ void CERTS_free(OPTIONAL STACK_OF(X509) *certs);
 /*!*****************************************************************************
  * @brief parse an X.500 Distinguished Name (DN)
  *
- * @param dn string to be parsed, format /type0=value0/type1=value1/type2=... where characters may be escaped by \
+ * @param dn string to be parsed, format "/type0=value0/type1=value1/type2=..." where characters may be escaped by '\'.
+ * The NULL-DN may be given as "/" or "".
  * @param chtype type of the string, e.g., MBSTRING_ASC, as defined in openssl/asn1.h
  * @param multirdn flag whether to allow multi-valued RDNs
  * @return ASN.1 representation of the DN, or null on error

--- a/src/credentials/cert.c
+++ b/src/credentials/cert.c
@@ -72,8 +72,9 @@ void CERTS_free(OPTIONAL STACK_OF(X509) *certs)
 }
 
 /*
- * dn is expected to be in the format /type0=value0/type1=value1/type2=...
- * where characters may be escaped by \
+ * dn is expected to be in the format "/type0=value0/type1=value1/type2=..."
+ * where characters may be escaped by '\'.
+ * The NULL-DN may be given as "/" or "".
  */
 /* adapted from OpenSSL:apps/lib/apps.c */
 X509_NAME* UTIL_parse_name(const char* dn, long chtype, bool multirdn)
@@ -102,7 +103,7 @@ X509_NAME* UTIL_parse_name(const char* dn, long chtype, bool multirdn)
     /* no multivalued RDN by default */
     mval[ne_num] = 0;
 
-    if(*sp++ not_eq '/')
+    if(*sp not_eq '\0' and *sp++ not_eq '/')
     { /* skip leading '/' */
         LOG(FL_ERR, "DN '%s' does not start with '/'.", dn);
         goto error;


### PR DESCRIPTION
So far, only `"/"` was allowed for NULL-DN, which is is a bit counter-intuitive.
Also document how to specify a NULL-DN.