### PR TITLE
CERTS_save() and FILES_store_certs(): document that the certs arg may be NULL

### DIFF
--- a/include/secutils/credentials/cert.h
+++ b/include/secutils/credentials/cert.h
@@ -81,13 +81,13 @@ STACK_OF(X509)
 /*!
  * @brief store the given list of certificates in given file and in format derived from file name extension
  *
- * @param certs list of certificates to save
+ * @param certs list of certificates to save, or null
  * @param file (path) name of the output file. Any previous contents are overwritten.
  * @param desc description of file contents to use for any error messages, or null
  * @return the number of certificates saved, or < 0 on error
  */
 /* this function is part of the genCMPClient API */
-int CERTS_save(const STACK_OF(X509) *certs, const char *file, OPTIONAL const char *desc);
+int CERTS_save(OPTIONAL const STACK_OF(X509) *certs, const char *file, OPTIONAL const char *desc);
 
 
 /*!

--- a/include/secutils/storage/files.h
+++ b/include/secutils/storage/files.h
@@ -266,13 +266,13 @@ bool FILES_store_key(const EVP_PKEY* pkey, const char* file, file_format_t forma
 /*!
  * @brief store the given list of certificates in given file and format
  *
- * @param certs list of certificates to save
+ * @param certs list of certificates to save, or null
  * @param file (path) name of the output file. Any previous contents are overwritten.
  * @param format the output format to use
  * @param desc description of file contents to use for any error messages, or null
  * @return the number of certificates saved, or < 0 on error
  */
-int FILES_store_certs(const STACK_OF(X509) * certs, const char* file, file_format_t format,
+int FILES_store_certs(OPTIONAL const STACK_OF(X509) * certs, const char* file, file_format_t format,
                       OPTIONAL const char* desc);
 
 

--- a/src/credentials/cert.c
+++ b/src/credentials/cert.c
@@ -56,7 +56,7 @@ STACK_OF(X509) *CERTS_load(const char *files, OPTIONAL const char *desc,
     return certs;
 }
 
-int CERTS_save(const STACK_OF(X509) *certs, const char *file, OPTIONAL const char *desc)
+int CERTS_save(OPTIONAL const STACK_OF(X509) *certs, const char *file, OPTIONAL const char *desc)
 {
     file_format_t format = FILES_get_format(file);
     if (format == FORMAT_UNDEF) {

--- a/src/storage/files.c
+++ b/src/storage/files.c
@@ -1333,7 +1333,7 @@ end:
  * writes out a stack of certificates in the given format to the given file
  * returns number of written certificates on success, < 0 on error
  * ########################################################################## */
-int FILES_store_certs(const STACK_OF(X509) * certs, const char* file, file_format_t format, OPTIONAL const char* desc)
+int FILES_store_certs(OPTIONAL const STACK_OF(X509) * certs, const char* file, file_format_t format, OPTIONAL const char* desc)
 {
     int n = sk_X509_num(certs);
     BIO* bio = 0;


### PR DESCRIPTION
In this case, an empty file is produced.