### PR TITLE
FILES_load_credentials(): allow 'certs' and 'key' arguments to be null

### DIFF
--- a/include/secutils/storage/files.h
+++ b/include/secutils/storage/files.h
@@ -194,6 +194,7 @@ bool FILES_load_pkcs12(const char* file, OPTIONAL const char* pass, OPTIONAL con
  * @param cert pointer to variable to assign the read primary certificate, or null
  * @param chain pointer to variable to assign the read list of further certificate, or null
  * @return true on success, else false
+ * @note Both the certs and key parameters can be null, resulting in empty credentials.
  * @note On success and in case the 'chain' parameter is not null (i.e., points to a variable),
  * if the variable contains null, a new stack of certs is allocated, else the certs are appended to the given stack.
  */

--- a/src/storage/files.c
+++ b/src/storage/files.c
@@ -439,12 +439,6 @@ bool FILES_load_credentials(OPTIONAL const char* certs, OPTIONAL OPTIONAL const 
                             OPTIONAL const char* source, OPTIONAL const char* engine, OPTIONAL const char* desc,
                             OPTIONAL EVP_PKEY** pkey, OPTIONAL X509** cert, OPTIONAL STACK_OF(X509) * *chain)
 {
-    if(certs is_eq 0 and key is_eq 0)
-    {
-        LOG_err("null pointer arguments for certs file and key input");
-        return 0;
-    }
-
     if(engine is_eq 0 and certs not_eq 0 and key not_eq 0 and strcmp(certs, key) is_eq 0)
     {
         char* pass = FILES_get_pass(source, desc);


### PR DESCRIPTION
I need this generalization for corner cases in the genCMPClient.