### PR TITLE
Improve credential saving

### DIFF
--- a/include/secutils/certstatus/cdp_util.h
+++ b/include/secutils/certstatus/cdp_util.h
@@ -41,7 +41,7 @@ typedef enum CDP_reason_flag {
 
 typedef int CDP_REASON_FLAGS;
 
-/* Copy a oneline representation of the X509_NAME into the buffer */
+/* Copy a one-line representation of the X509_NAME into the buffer */
 int CDP_get_x509_name(
     X509_NAME       *name,
     char            *name_utf8_buf,

--- a/include/secutils/certstatus/certstatus.h
+++ b/include/secutils/certstatus/certstatus.h
@@ -44,7 +44,7 @@ typedef struct revstatus_access_st
 #define X509_V_FLAG_NONFINAL_CHECK  0x10000000 /* do not log failure as error */
 
 /*!*****************************************************************************
- * @brief log messsage about the given certificate, focusing on CDP contents
+ * @brief log message about the given certificate, focusing on CDP contents
  * in extensions with NID_crl_distribution_points or NID_freshest_crl
  *
  * @note This is more of a debug function to show which cert is currently processed.
@@ -128,7 +128,7 @@ bool check_cert_revocation(X509_STORE_CTX* ctx, OPTIONAL OCSP_RESPONSE* resp);
  * but uses any stapled OCSP resp, local CRLs, else OCSP or CRLs as far as required.
  * @param ctx pointer to verification context structure including the cert(s) to check
  * @return true on success, false on rejection or checking error (inconclusive)
- * @note using result type 'int' rather than 'bool' for compatiblity with X509_STORE_set_check_revocation()
+ * @note using result type 'int' rather than 'bool' for compatibility with X509_STORE_set_check_revocation()
  */
 int check_revocation_any_method(X509_STORE_CTX* ctx);
 

--- a/include/secutils/certstatus/crl_mgmt.h
+++ b/include/secutils/certstatus/crl_mgmt.h
@@ -27,7 +27,7 @@ extern "C" {
 typedef struct crlmgmt_data_st CRLMGMT_DATA;
 
 /*!
- * @brief The function creates and initialises the context of the CRL management.
+ * @brief The function creates and initializes the context of the CRL management.
  *        The context is used during the verification of a certificate chain
  *        and holds parameter necessary for CRL download, a potential proxy,
  *        caching and other parameters.
@@ -41,7 +41,7 @@ CRLMGMT_DATA *CRLMGMT_DATA_new(void);
  * @brief The function frees the context of the CRL management created by
  *        CRLMGMT_DATA_new(). Only the context itself is freed. Strings
  *        that have been set with the setter functions are in the
- *        responsability of the caller.
+ *        responsibility of the caller.
  *
  * @param cmdat pointer to the CRL management data structure
  */
@@ -61,7 +61,7 @@ const char *CRLMGMT_DATA_get_proxy_url(
 
 /*!
  * @brief The function sets the proxy url in the CRL management context.
- * It will be used to send CDP URLs to inr the form C<url?url=CDP_URL>
+ * It will be used to send CDP URLs in the form C<url?url=CDP_URL>
  * to send issuer Distinguished Names (DNs) to in the form C<url?issuer=DN>.
 
  * @note  The proxy url is not copied into the structure. Therefore the
@@ -113,7 +113,7 @@ const char *CRLMGMT_DATA_get_crl_cache_dir(
  * @brief The function sets the cache directory in the CRL management context.
  * @note  The directory name is not copied into the structure. Therefore the
  *        parameter cache directory must exist during the lifetime of the context.
- *        If not null, it must end with the (potentally platform-specific) path separator.
+ *        If not null, it must end with the (potentially platform-specific) path separator.
  *
  * @param cmdat pointer to the CRL management data structure
  * @param crl_cache_dir the cache directory

--- a/include/secutils/certstatus/ocsp.h
+++ b/include/secutils/certstatus/ocsp.h
@@ -48,8 +48,8 @@ static const int OCSP_DEFAULT_TIMEOUT = 10; /* in seconds */
  *
  * @param ts pointer to trust store containing verification parameters
  * @param untrusted a stack of certs that may be used for chain building, or null
- * @param cert the cerificate to check
- * @param issuer the issuer cerificate
+ * @param cert the certificate to check
+ * @param issuer the issuer certificate
  * @param resp the OCSP response to use
  * @return 1 on success, 0 on rejection (i.e., cert revoked), -1 on error
  */
@@ -62,8 +62,8 @@ int check_ocsp_resp(X509_STORE* ts, STACK_OF(X509) *untrusted,
  *
  * @param ctx verification context containing verification parameters etc.
  * @param untrusted a stack of certs that may be used for chain building, or null
- * @param cert the cerificate to check
- * @param issuer the issuer cerificate
+ * @param cert the certificate to check
+ * @param issuer the issuer certificate
  * @return 1 on success, 0 on rejection (i.e., cert revoked), -2 on no OCSP response available, -1 on other error
  */
 int check_cert_status_ocsp(X509_STORE_CTX* ctx, STACK_OF(X509) *untrusted,

--- a/include/secutils/config/opt.h
+++ b/include/secutils/config/opt.h
@@ -21,7 +21,7 @@
 
 /* all these definitions are used by the genCMPClient CLI implementation */
 
-extern const char OPT_more_str[]; /** indicates further line of help text for currenct option */
+extern const char OPT_more_str[]; /** indicates further line of help text for current option */
 extern const char OPT_section_str[]; /** marks a section header in help text */
 extern const char OPT_param_str[]; /** marks a parameter option in help text */
 #define OPT_MORE(text)    { OPT_more_str   , OPT_BOOL, {.num = 0}, {0}, text }
@@ -68,7 +68,7 @@ bool OPT_init(opt_t options[]);
  * @brief print the help strings for option/config variables to the given BIO
  * @param options list of options, terminated by a {0} entry
  * @param bio the OpenSSL BIO to print to (may be linked, e.g., to stdout)
- * @return false on error (e.g., options or bio is null), else true
+ * @return false on error (e.g., options or BIO is null), else true
  */
 bool OPT_help(opt_t options[], BIO* bio);
 

--- a/include/secutils/credentials/cert.h
+++ b/include/secutils/credentials/cert.h
@@ -113,14 +113,14 @@ X509_NAME* UTIL_parse_name(const char* dn, long chtype, bool multirdn);
 
 
 /*!*****************************************************************************
- * @brief log messsage about the given certificate, printing its subject
+ * @brief log message about the given certificate, printing its subject
  *
  * @param func the name of the reporting function or component, or null
  * @param file the current source file path name, or null
  * @param lineno the current line number, or 0
  * @param level the nature of the message, i.e., its severity level
  * @param msg the message to be logged
- * @param cert the certificate the message referts to
+ * @param cert the certificate the message refers to
  */
 void LOG_cert(OPTIONAL const char* func, OPTIONAL const char* file, int lineno, severity level,
               const char* msg, const X509* cert);

--- a/include/secutils/credentials/cert.h
+++ b/include/secutils/credentials/cert.h
@@ -81,7 +81,7 @@ STACK_OF(X509)
 /*!
  * @brief store the given list of certificates in given file and in format derived from file name extension
  *
- * @param certs list of certificates to save, or null
+ * @param certs list of certificates to save, or null to save empty list
  * @param file (path) name of the output file. Any previous contents are overwritten.
  * @param desc description of file contents to use for any error messages, or null
  * @return the number of certificates saved, or < 0 on error

--- a/include/secutils/credentials/credentials.h
+++ b/include/secutils/credentials/credentials.h
@@ -203,8 +203,9 @@ CREDENTIALS* CREDENTIALS_load_dv(OPTIONAL const char* certs, OPTIONAL const char
  *   the key is not stored because this does not apply for the engine interface.
  * @param desc (optional) is used if present for forming more descriptive error messages
  * @return true on success, else failure
- * @note If the 'certs' and 'key' arguments are equal the certs and the key are written jointly to the same PKCS#12
- *file, else they are written to PEM files.
+ * @note If the 'certs' and 'key' arguments are equal and the file name extension is ".p12" or ".pkcs12",
+ * the certs and the key are written jointly to the same PKCS#12 file.
+ * Otherwise they are written in PEM format, potentially jointly to the same file.
  *******************************************************************************/
 /* this function is part of the genCMPClient API */
 bool CREDENTIALS_save(const CREDENTIALS* creds, OPTIONAL const char* certs, OPTIONAL const char* key,

--- a/include/secutils/credentials/credentials.h
+++ b/include/secutils/credentials/credentials.h
@@ -94,7 +94,7 @@ char* CREDENTIALS_get_pwdref(const CREDENTIALS* creds);
  * @brief set private key component of the given credentials
  * @note the current component value is not freed but overwritten.
  *
- * @param pkey (optiona) value to be set
+ * @param pkey (optional) value to be set
  * @param creds credentials to modify
  * @return true on success, else failure (e.g, null creds argument)
  *******************************************************************************/
@@ -236,7 +236,7 @@ static const char* const CREDS_DIR_DEFAULT = "certs/creds";
  * @note file name is derived from CREDS_DIR_ENV (defaulting to CREDS_DIR_DEFAULT), cid, and extension ".p12".
  * @note uses DV-based encryption, which also protects integrity&authenticity.
  *
- * @param cid identfier of the component credentials
+ * @param cid identifier of the component credentials
  * @return pointer to a new CREDENTIALS structure, or null on error
  *******************************************************************************/
 CREDENTIALS* CREDENTIALS_get(component_creds_id cid);
@@ -246,7 +246,7 @@ CREDENTIALS* CREDENTIALS_get(component_creds_id cid);
  * @note file name is derived from CREDS_DIR_ENV (defaulting to CREDS_DIR_DEFAULT), cid, and extension ".p12".
  * @note uses DV-based encryption, which also protects integrity&authenticity.
  *
- * @param cid identfier of the component credentials
+ * @param cid identifier of the component credentials
  * @param creds credentials to store
  * @return true on success, else failure
  *******************************************************************************/
@@ -263,7 +263,7 @@ typedef void CREDENTIALS_update_cb(const char* tag);
 /*!*****************************************************************************
  * @brief register callback to trigger when credentials are stored
  *
- * @param tag identfier of the credentials
+ * @param tag identifier of the credentials
  * @param fn (optional) callback function to be set, or null to clear entry
  * @return true on success, false on failure
  *******************************************************************************/

--- a/include/secutils/credentials/store.h
+++ b/include/secutils/credentials/store.h
@@ -43,7 +43,7 @@ bool STORE_set1_host_ip(X509_STORE* truststore, const char* name, const char* ip
  * @param store the trust store to be extended
  * @param crls the list of CRLs to be added, or null.
  * @return true on success, false on failure
- * @note A warning is given for each exired CRL. X509_V_FLAG_CRL_CHECK is set in the store.
+ * @note A warning is given for each expired CRL. X509_V_FLAG_CRL_CHECK is set in the store.
  */
 /* this function is part of the genCMPClient API */
 bool STORE_add_crls(X509_STORE* store, OPTIONAL const STACK_OF(X509_CRL) * crls);
@@ -119,7 +119,7 @@ bool STORE_set_crl_callback(X509_STORE* store,
 
 /*!*****************************************************************************
  * @brief use the CRL fetching function specified in the given trust store
- * @param store the certificate trust store containin the callback information
+ * @param store the certificate trust store containing the callback information
  * @param url the location of the CDP to use, or null
  * @param timeout number of seconds the HTTP transaction may take, or 0 for infinite or -1 for default
  * @param cert the certificate for which the status should be checked using the CRL
@@ -268,7 +268,7 @@ const char* STORE_get0_host(X509_STORE* store);
  * @note used to improve diagnostic output of CREDENTIALS_print_cert_verify_cb()
  *
  * @param store the affected certificate store
- * @param bio the SSL/TLS bio to set, or null to clear it
+ * @param bio the SSL/TLS BIO to set, or null to clear it
  * @return true on success, false on failure
  */
 /* this function is used by the genCMPClient API implementation */
@@ -278,7 +278,7 @@ bool STORE_set0_tls_bio(X509_STORE* store, OPTIONAL BIO* bio);
  * @brief get the SSL BIO indicating if TLS is active, for diagnostics
  *
  * @param store the certificate store to read from
- * @return the SSL/TLS bio that has been set, or null if unset or on failure
+ * @return the SSL/TLS BIO that has been set, or null if unset or on failure
  */
 BIO* STORE_get0_tls_bio(X509_STORE* store);
 # endif /* !defined(SECUTILS_NO_TLS) */

--- a/include/secutils/credentials/trusted.h
+++ b/include/secutils/credentials/trusted.h
@@ -34,7 +34,7 @@ static const char* const TRUST_CONFIG_ENTRY_CRLS = "crls";
  * trusted.2 = certs/trusted2.crt
  * @note the section may contain multiple entries for CRL files, with names derived from TRUST_CONFIG_ENTRY_CRLS
  *
- * @param cid identfier of the component, which indicates the config file section to use, or TRUST_CONFIG_SECTION_DEFAULT if it is 0
+ * @param cid identifier of the component, which indicates the config file section to use, or TRUST_CONFIG_SECTION_DEFAULT if it is 0
  * @param vpm OpenSSL certificate verification parameters to be taken over, or null for default
  * @param ctx (optional) pointer to UTA context for checking file integrity&authenticity using ICV
  * @return pointer to a new CREDENTIALS structure, or null on error

--- a/include/secutils/credentials/verify.h
+++ b/include/secutils/credentials/verify.h
@@ -80,7 +80,7 @@ bool verify_cb_cert(X509_STORE_CTX* store_ctx, X509* cert, int err);
  * the chain of certificates between the cert and the trusted certs in the trust store
  * @param trust_store pointer to structure containing trusted (root) certs and further verification parameters
  * @note trust_store may contain CRLs loaded via STORE_load_crl_dir()
- * @return < 0 on on verification error, 0 for invalid cert, 1 for vaild cert
+ * @return < 0 on on verification error, 0 for invalid cert, 1 for valid cert
  *******************************************************************************/
 int CREDENTIALS_verify_cert(OPTIONAL uta_ctx* ctx, X509* cert,
                             OPTIONAL const STACK_OF(X509) * untrusted, X509_STORE* trust_store);

--- a/include/secutils/crypto/crypto.h
+++ b/include/secutils/crypto/crypto.h
@@ -24,7 +24,7 @@ typedef int (*pEVP_INIT_EX)(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type,
 typedef const EVP_CIPHER* (*pAES_GCM)(void);
 
 /*!
- * @brief The function creates and initialises the context of encryption/description
+ * @brief The function creates and initializes the context of encryption/description
  *        operation. And after that the function sets length of initialization vector (IV)
  *
  * @param key key used for encryption and integrity protection

--- a/include/secutils/storage/files.h
+++ b/include/secutils/storage/files.h
@@ -84,7 +84,7 @@ file_format_t FILES_get_format(const char* filename);
  * @param format the format to expect for the file contents
  * @param source the password source to use in case the input file is encrypted, or null
  * @param desc description of file contents to use for any error messages, or null
- * @return null on error, else a stack of certs with the first/primary one on top
+ * @return null on error, else a stack of certs that may be empty or has the first/primary one on top
  */
 STACK_OF(X509)
     * FILES_load_certs(const char* file, file_format_t format, OPTIONAL const char* source, OPTIONAL const char* desc);
@@ -97,7 +97,7 @@ STACK_OF(X509)
  * @param format the format to expect for the file contents
  * @param source the password source to use in case the input file is encrypted, or null
  * @param desc description of file contents to use for any error messages, or null
- * @return null on error, else the first certificate contained in the file
+ * @return null on error, else the first certificate in the file
  */
 X509* FILES_load_cert(const char* file, file_format_t format, OPTIONAL const char* source, OPTIONAL const char* desc);
 
@@ -109,7 +109,7 @@ X509* FILES_load_cert(const char* file, file_format_t format, OPTIONAL const cha
  * @param format the format to try first when reading the file contents
  * @param source the password source to use in case the input is encrypted, or null
  * @param desc description of file contents to use for any error messages, or null
- * @return null on error, else a stack of certs with the first/primary one on top
+ * @return null on error, else a stack of certs that may be empty or has the first/primary one on top
  */
 STACK_OF(X509)
     * FILES_load_certs_autofmt(const char* file, file_format_t format, OPTIONAL const char* source,
@@ -123,7 +123,7 @@ STACK_OF(X509)
  * @param format the format to try first when reading file contents
  * @param source the password source to use in case the input is encrypted, or null
  * @param desc description of file contents to use for any error messages, or null
- * @return null on error, else a stack of certs with the first/primary one on top
+ * @return null on error, else a stack of certs that may be empty or has the first/primary one on top
  * @note duplicate certificates among different input files are included only once
  */
 /* this function is used by the genCMPClient API implementation */
@@ -267,7 +267,7 @@ bool FILES_store_key(const EVP_PKEY* pkey, const char* file, file_format_t forma
 /*!
  * @brief store the given list of certificates in given file and format
  *
- * @param certs list of certificates to save, or null
+ * @param certs list of certificates to save, or null to save empty list
  * @param file (path) name of the output file. Any previous contents are overwritten.
  * @param format the output format to use
  * @param desc description of file contents to use for any error messages, or null
@@ -332,15 +332,20 @@ bool FILES_store_pkcs12(OPTIONAL const EVP_PKEY* pkey, OPTIONAL const X509* cert
  * @param key (optional) private key to save
  * @param cert (optional) related certificate to save
  * @param certs (optional) related certificate chain to save
- * @param keyfile (optional) path name of the key output file. Any previous contents are overwritten.1
- * @param file (optional) name of the cert(s) output file. Any previous contents are overwritten.
+ * @param keyfile (optional) path name of the key output file.
+ * Must not be null if key is given. Any previous content is overwritten.
+ * @param file (optional) name of the cert(s) output file.
+ * Must not be null if cert(s) are given. Any previous contents are overwritten.
  * @param format the output format to use.
- * If the 'keyfile' and 'file' arguments are present and equal, the certs and the key are written jointly to the same
- * file, where only PKCS#12 is supported.
  * @param source the password source to use for decryption, or null
  * @param desc description of file contents to use for any error messages, or null
  * @return true on success, else false
+ * @note At least one of key, cert, or certs must not be null.
  * @note If the file format is PEM or ASN1 and both cert and certs are present, the cert is stored before the certs.
+ * @note If the 'keyfile' and 'file' arguments are present and equal,
+ * all of the cert, certs, and key are written jointly to the same file;
+ * in this case the cert(s) are stored before the key if the file format is PEM or ASN1.
+ * @note A warning is given when saving multiple credentials to the same ASN.1 DER encoded file.
  */
 bool FILES_store_credentials(OPTIONAL const EVP_PKEY* key, OPTIONAL const X509* cert, OPTIONAL STACK_OF(X509) * certs,
                              OPTIONAL const char* keyfile, OPTIONAL const char* file, file_format_t format,

--- a/include/secutils/storage/files.h
+++ b/include/secutils/storage/files.h
@@ -217,7 +217,7 @@ EVP_PKEY *FILES_load_pubkey(const char *file, file_format_t format,
 
 
 /*!
- * @brief load a public key from the given file with flexbile format
+ * @brief load a public key from the given file with flexible format
  *
  * @param file (path) name of the input file
  * @param format the format to try first when reading the file contents - currently FORMAT_PEM or FORMAT_ASN1
@@ -241,7 +241,7 @@ X509_REQ* FILES_load_csr(const char* file, file_format_t format, OPTIONAL const 
 
 
 /*!
- * @brief load a PKCS#10 CSR from the given file with flexbile format
+ * @brief load a PKCS#10 CSR from the given file with flexible format
  *
  * @param file (path) name of the input file
  * @param format the format to try first when reading the file contents
@@ -352,7 +352,7 @@ bool FILES_store_credentials(OPTIONAL const EVP_PKEY* key, OPTIONAL const X509* 
                              OPTIONAL const char* source, OPTIONAL const char* desc);
 
 /*!
- * @brief load CRL via HTTP or from the given file, with flexbile format
+ * @brief load CRL via HTTP or from the given file, with flexible format
  *
  * @param src input file or URL (in PEM or DER format) or URL
  * @param format FORMAT_HTTP or input format to try first, FORMAT_PEM or FORMAT_ASN1
@@ -364,7 +364,7 @@ bool FILES_store_credentials(OPTIONAL const EVP_PKEY* key, OPTIONAL const X509* 
 X509_CRL* FILES_load_crl_autofmt(const char* src, file_format_t format, int timeout, const char* desc);
 
 /*!
- * @brief load CRLs via HTTP or from the given file, with flexbile format
+ * @brief load CRLs via HTTP or from the given file, with flexible format
  *
  * @param src input file or URL (in PEM or DER format) containing CRLs
  * @param format FORMAT_HTTP or input format to try first, either FORMAT_PEM or FORMAT_ASN1

--- a/include/secutils/storage/uta_api.h
+++ b/include/secutils/storage/uta_api.h
@@ -37,7 +37,7 @@ uta_ctx* uta_open(void); /* may be called more than once */
 
 
 /*!
- * @brief deinitialize the given use of the UTA library
+ * @brief de-initialize the given use of the UTA library
  * @param ctx the uta context to free
  * @return true on success, else false
  */

--- a/include/secutils/util/log.h
+++ b/include/secutils/util/log.h
@@ -48,7 +48,7 @@ typedef bool (*LOG_cb_t)(OPTIONAL const char* func, OPTIONAL const char* file, i
                          const char* msg);
 
 /*!
- * @brief initialize the logging functionality of the secutils
+ * @brief initialize the logging functionality of libsecutils
  * @note this function may be called multiple times
  * @note this function does not affect the application name optionally set by LOG_set_name()
  *

--- a/include/secutils/util/util.h
+++ b/include/secutils/util/util.h
@@ -175,7 +175,7 @@ typedef unsigned char uint8_t;
 typedef u_int32_t uint32_t;
 typedef u_int64_t uint64_t;
 #  define OPENSSL_strndup strndup
-#  define CRYPTO_free_ex_index(cls_idx, idx) /* sorry, no-op (yet no memleak) */
+#  define CRYPTO_free_ex_index(cls_idx, idx) /* sorry, no-op (yet no mem leak) */
 #  define X509_get0_extensions(x) ((x)->cert_info->extensions)
 #  define X509_get_extension_flags(x) (X509_check_purpose((x), -1, -1), \
                                        (x)->ex_flags)
@@ -204,7 +204,7 @@ STACK_OF(X509) *X509_STORE_get1_all_certs(X509_STORE *store);
  *        or null for the default: UTIL_SECUTILS_NAME
  * @note calls exit(EXIT_FAILURE) on error,
  *        e.g., version mismatch or initialization failure
- * @note this function is called upon libarary loading via STORE_EX_init_index()
+ * @note this function is called upon library loading via STORE_EX_init_index()
  ******************************************************************************/
 /* this function is used by the genCMPClient API implementation */
 void UTIL_setup_openssl(long version, OPTIONAL const char *build_name);
@@ -321,8 +321,8 @@ bool UTIL_get_random(void *buf, size_t len);
  * This function is a helper that could possibly be replaced by built-in one.
  * It respects the receiving buffer length and always NUL terminates the buffer.
  * In addition it returns the buffer size needed when requested.
- * Normaly there are equivalents to this on most platforms,
- * which unfortunately are mostly platfrom dependent. So this placeholder is
+ * Normally there are equivalents to this on most platforms,
+ * which unfortunately are mostly platform dependent. So this placeholder is
  * used here, but could possibly be replaced by a better lib function on the
  * target platform.
  *

--- a/src/certstatus/cdp_util.c
+++ b/src/certstatus/cdp_util.c
@@ -105,7 +105,7 @@ const char *CDP_get_crl_distribution_point_from_distpoint(
      */
     if (distpoint->reasons) {
         CDP_REASON_FLAGS reason_flags = 0;
-        CDP_REASON_FLAGS single_flag = 1;   /* this is shifted throug all flags */
+        CDP_REASON_FLAGS single_flag = 1;   /* this is shifted through all flags */
         int bit;
         for (bit = 0; bit < CDP_REASON_FLAGSCOUNT; ++bit) {
             if (ASN1_BIT_STRING_get_bit(distpoint->reasons, bit)) {
@@ -122,7 +122,7 @@ const char *CDP_get_crl_distribution_point_from_distpoint(
 
     if (distpoint->distpoint) {
         if (distpoint->distpoint->type == 0) {
-            /* type 0 means this is a fullname cdp */
+            /* type 0 means this is a full-name cdp */
             /* RFC 5280 Page 46
              * If the DistributionPointName contains a general name of type URI, the
              * following semantics MUST be assumed: the URI is a pointer to the

--- a/src/certstatus/crl_mgmt.c
+++ b/src/certstatus/crl_mgmt.c
@@ -220,7 +220,7 @@ static X509_CRL *get_crl_by_download_or_from_cache(const CRLMGMT_DATA *data,
 CRLMGMT_DATA *CRLMGMT_DATA_new(void)
 {
     if (nidCrlNextPublish==0) {
-        // TODO this is not threadsafe
+        // TODO this is not thread-safe
         nidCrlNextPublish = OBJ_create("1.3.6.1.4.1.311.21.4",
             SN_crl_next_publish, LN_crl_next_publish);
     }

--- a/src/certstatus/ocsp.c
+++ b/src/certstatus/ocsp.c
@@ -176,7 +176,7 @@ int check_ocsp_resp(X509_STORE* ts, STACK_OF(X509) *untrusted,
  * Get an OCSP_RESPONSE from a responder URL for the given cert and issuer.
  * This is a simplified version. It examines certificates each time and makes
  * one OCSP responder query for each request. A full version would store details
- * such as the OCSP certificate IDs and minimise the number of OCSP responses
+ * such as the OCSP certificate IDs and minimize the number of OCSP responses
  * by caching them until they were considered "expired".
  */
 static OCSP_RESPONSE* get_ocsp_resp(X509* cert, X509* issuer,

--- a/src/config/config_update.c
+++ b/src/config/config_update.c
@@ -62,7 +62,7 @@ static int refactor_entry(char* src_p, char* dest_p, const char* const key_p, co
         return -1;
     }
 
-    /* copy the whole line proactively */
+    /* copy the whole line pro-actively */
     if(not copy_line_substring(dest_p, src_p, &line_len, max_dest_len))
     {
         goto len_err;
@@ -127,7 +127,7 @@ len_err:
 #define c_line_buf_size 512   /* .5 kB including '\0' */
 
 /*
- * @warning security note: `file_buffer` is a `tained` value in the sense of
+ * @warning security note: `file_buffer` is a `tainted` value in the sense of
  * https://wiki.sei.cmu.edu/confluence/display/c/FIO30-C.+Exclude+user+input+from+format+strings
  */
 static char file_buffer[c_file_buf_size] = {0};

--- a/src/connections/tls.c
+++ b/src/connections/tls.c
@@ -322,7 +322,7 @@ err:
     OPENSSL_free(host_str);
     /* release the intermediate connection structure */
     CONN_free(conn);
-    /* on error, releasee the SSL/TLS structure */
+    /* on error, release the SSL/TLS structure */
     if(0 is_eq res)
     {
         TLS_drop(ssl);

--- a/src/credentials/cert.c
+++ b/src/credentials/cert.c
@@ -100,7 +100,7 @@ X509_NAME* UTIL_parse_name(const char* dn, long chtype, bool multirdn)
         goto error;
     }
 
-    /* no multivalued RDN by default */
+    /* no multi-valued RDN by default */
     mval[ne_num] = 0;
 
     if(*sp not_eq '\0' and *sp++ not_eq '/')
@@ -159,7 +159,7 @@ X509_NAME* UTIL_parse_name(const char* dn, long chtype, bool multirdn)
             else if(*sp is_eq '/')
             { /* start of next element */
                 sp++;
-                /* no multivalued RDN by default */
+                /* no multi-valued RDN by default */
                 mval[ne_num + 1] = 0;
                 break;
             }

--- a/src/credentials/credentials.c
+++ b/src/credentials/credentials.c
@@ -337,7 +337,7 @@ bool CREDENTIALS_save(const CREDENTIALS* creds, OPTIONAL const char* certs, OPTI
         source = 0;
     }
 
-    file_format_t format = key not_eq 0 and strcmp(key, certs) is_eq 0 ? FORMAT_PKCS12 : FORMAT_PEM;
+    file_format_t format = key not_eq 0 and strcmp(key, certs) is_eq 0 ? FILES_get_format(key) : FORMAT_PEM;
     bool res = FILES_store_credentials(pkey, creds->cert, creds->chain, key, certs, format, source, desc);
     if(0 is_eq res)
     {

--- a/src/credentials/store.c
+++ b/src/credentials/store.c
@@ -243,8 +243,13 @@ bool STORE_load_more_check(X509_STORE** pstore, const char* file,
     if(ctx is_eq 0 or FILES_check_icv(ctx, file))
     {
         STACK_OF(X509)* certs = FILES_load_certs_autofmt(file, format, 0 /* source */, desc);
-        if(0 is_eq certs)
+        if(sk_X509_num(certs) <= 0)
         {
+            if (certs != 0)
+            {
+                LOG(FL_ERR, "No %s in %s", desc not_eq 0 ? desc : "certs", file);
+            }
+            CERTS_free(certs);
             goto err;
         }
 

--- a/src/credentials/verify.c
+++ b/src/credentials/verify.c
@@ -97,6 +97,9 @@ int CREDENTIALS_print_cert_verify_cb(int ok, X509_STORE_CTX* store_ctx)
                    This works for names we set ourselves but not verify_hostname. */
                 expected = STORE_get0_host(ts);
                 break;
+            case X509_V_ERR_INVALID_PURPOSE:
+                /* TODO assign, if possible: expected = ...; */
+                break;
             default:
                 break;
         }

--- a/src/storage/files.c
+++ b/src/storage/files.c
@@ -276,7 +276,7 @@ char* FILES_get_pass(OPTIONAL const char* source, OPTIONAL const char* desc)
         {
             LOG(FL_ERR, "Cannot access file descriptor %s\n", source + strlen(sec_FD_STR));
         }
-        /* Cannott do BIO_gets on an fd BIO so add a buffering BIO */
+        /* Cannot do BIO_gets on an fd BIO so add a buffering BIO */
         bio = BIO_push(BIO_new(BIO_f_buffer()), bio);
 #endif
     }
@@ -834,7 +834,7 @@ X509* FILES_load_cert(const char* file, file_format_t format, OPTIONAL const cha
 
 /* adapted from OpenSSL:apps/lib/apps.c just for visibility reasons */
 #ifndef OPENSSL_NO_ENGINE
-/* Try to load an engine in a shareable library */
+/* Try to load an engine in a sharable library */
 static ENGINE* try_load_engine(const char* engine)
 {
     ENGINE* e = ENGINE_by_id("dynamic");
@@ -1734,7 +1734,7 @@ STACK_OF(X509_CRL) * FILES_load_crls_multi(const char* srcs, file_format_t forma
 #if 0
             if(OSSL_CMP_expired(X509_CRL_get0_nextUpdate(crl), vpm))
             {
-                /* well, should ignore expiry of base CRL if delta CRL is valid */
+                /* well, should ignore expiration of base CRL if delta CRL is valid */
                 char* issuer =
                     X509_NAME_oneline(X509_CRL_get_issuer(crl), 0, 0);
                 LOG(FL_ERR, "CRL from '%s' issued by '%s' has expired",


### PR DESCRIPTION
Improve `FILES_store_{credentials,certs}()`, `{CREDENTIALS,CERTS}_save()`, and update their docs accordingly:
* solve TODO such that `FILES_store_credentials()`  can now jointly save certs and keys to the same file not only for PKCS#12 format, but also for PEM (and DER/ASN.1) format.
* Fix corner cases such that 
  - empty lists of certs really get stored (rather than partially ignoring them)
  - `NULL` cert list pointers are not treated as errors but as empty lists of certs

* add TODO to `CREDENTIALS_print_cert_verify_cb() ` for showing expected trust anchor purpose


