### PR TITLE
fix(debian): wrong dependency of libsecutils-bins

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,7 @@ Description: libsecutils C headers
  Only needed for development
 
 Package: libsecutils-bins
-Depends: libsecutils${binary:Version}, ${shlibs:Depends}, ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}
 Architecture: any
 Description: libsecutils helper binaries
  Stand-alone helper CLI applications using libsecutils


### PR DESCRIPTION
During installation of `libsecutils-bins` apt complains that `libsecutils1.0` can't be found. But `libsecutils1.0` (or `libsecutils<version>`) doesn't seems to be a package which can be built by this repository anyways so this dependency will never be resolved