### PR TITLE
CMake default build mode: Release; fix build issues and small bugs; support MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,9 +125,9 @@ message(STATUS "build mode: ${CMAKE_BUILD_TYPE}")
 add_definitions(
   -Wall -Woverflow -Wextra -Wswitch -Wmissing-prototypes -Wstrict-prototypes
   -Wformat -Wtype-limits -Wundef -Wconversion -Wno-shadow -Wno-conversion
-  -Wno-sign-conversion -Wno-unused-parameter -Wno-sign-compare -Wpointer-arith
+  -Wno-sign-conversion  -Wno-sign-compare -Wpointer-arith
   -Wformat -Wformat-security -Wno-declaration-after-statement -Wno-vla
-  # TODO enable -Wconversion -Wsign-conversion -Wsign-compare -Wunused-parameter
+  # TODO enable -Wconversion -Wsign-conversion -Wsign-compare
   )
 add_definitions(-pedantic -DPEDANTIC -Werror)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,11 +106,13 @@ set(INC_PUBLIC_HDRS
 
 include_directories(${INC_DIR}/.. ${INC_DIR})
 
-if(CMAKE_BUILD_TYPE MATCHES Release OR DEFINED ENV{NDEBUG})
-  message(STATUS "build mode: Release")
+if(DEFINED ENV{NDEBUG} OR NOT CMAKE_BUILD_TYPE MATCHES Debug)
+  set(CMAKE_BUILD_TYPE Release
+      CACHE STRING "Choose the type of build." FORCE)
   add_definitions(-DNDEBUG=1 -O2)
 else()
-  message(STATUS "build mode: Debug")
+  set(CMAKE_BUILD_TYPE Debug
+      CACHE STRING "Choose the type of build." FORCE)
   add_definitions(-g -O0)
 
   set(DEBUG_FLAGS "-fsanitize=address,undefined -fno-sanitize-recover=all") # must use quotes on MacOSX
@@ -118,6 +120,7 @@ else()
   link_libraries(${DEBUG_FLAGS})
   set(CMAKE_SHARED_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS} ${DEBUG_FLAGS}) # workarund for link_libraries() ignored on MacOSX
 endif()
+message(STATUS "build mode: ${CMAKE_BUILD_TYPE}")
 
 add_definitions(
   -Wall -Woverflow -Wextra -Wswitch -Wmissing-prototypes -Wstrict-prototypes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,10 +125,11 @@ message(STATUS "build mode: ${CMAKE_BUILD_TYPE}")
 
 add_compile_options(
   -Wall -Woverflow -Wextra -Wswitch -Wmissing-prototypes -Wstrict-prototypes
-  -Wformat -Wtype-limits -Wundef -Wconversion -Wno-shadow -Wno-conversion
-  -Wno-sign-conversion  -Wno-sign-compare -Wpointer-arith
-  -Wformat -Wformat-security -Wno-declaration-after-statement -Wno-vla
-  # TODO enable -Wconversion -Wsign-conversion -Wsign-compare
+  -Wformat -Wformat-security -Wtype-limits -Wundef -Wconversion
+  -Wsign-compare -Wpointer-arith -Wunused-parameter)
+add_compile_options( # TODO clean up code and enable instead:
+  -Wsign-conversion -Wno-shorten-64-to-32 -Wno-c99-extensions
+  -Wno-shadow -Wno-declaration-after-statement -Wno-vla
   )
 add_compile_options(-pedantic -Werror)
 add_compile_definitions(-DPEDANTIC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,11 +30,11 @@ if(NOT("$ENV{OPENSSL_DIR}" STREQUAL ""))
   set(OpenSSL_INCLUDE_DIRS $ENV{OPENSSL_DIR}/include)
   set(OPENSSL_LIBRARIES ${OPENSSL_LIB}/libssl${CMAKE_SHARED_LIBRARY_SUFFIX}
                         ${OPENSSL_LIB}/libcrypto${CMAKE_SHARED_LIBRARY_SUFFIX})
-  add_definitions(-isystem ${OpenSSL_INCLUDE_DIRS})
+  include_directories(SYSTEM ${OpenSSL_INCLUDE_DIRS})
 else()
   find_package(OpenSSL REQUIRED)
   message(STATUS "using OpenSSL package, with version " ${OPENSSL_VERSION})
-  add_definitions(-isystem ${OPENSSL_INCLUDE_DIR})
+  include_directories(SYSTEM ${OPENSSL_INCLUDE_DIR})
 endif()
 
 set(SRC_DIR ${PROJECT_SOURCE_DIR}/src)
@@ -109,27 +109,29 @@ include_directories(${INC_DIR}/.. ${INC_DIR})
 if(DEFINED ENV{NDEBUG} OR NOT CMAKE_BUILD_TYPE MATCHES Debug)
   set(CMAKE_BUILD_TYPE Release
       CACHE STRING "Choose the type of build." FORCE)
-  add_definitions(-DNDEBUG=1 -O2)
+  add_compile_options(-O2)
+  add_compile_definitions(-DNDEBUG=1)
 else()
   set(CMAKE_BUILD_TYPE Debug
       CACHE STRING "Choose the type of build." FORCE)
-  add_definitions(-g -O0)
+  add_compile_options(-g -O0)
 
   set(DEBUG_FLAGS "-fsanitize=address,undefined -fno-sanitize-recover=all") # must use quotes on MacOSX
-  add_definitions(${DEBUG_FLAGS})
+  add_compile_options(${DEBUG_FLAGS})
   link_libraries(${DEBUG_FLAGS})
   set(CMAKE_SHARED_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS} ${DEBUG_FLAGS}) # workarund for link_libraries() ignored on MacOSX
 endif()
 message(STATUS "build mode: ${CMAKE_BUILD_TYPE}")
 
-add_definitions(
+add_compile_options(
   -Wall -Woverflow -Wextra -Wswitch -Wmissing-prototypes -Wstrict-prototypes
   -Wformat -Wtype-limits -Wundef -Wconversion -Wno-shadow -Wno-conversion
   -Wno-sign-conversion  -Wno-sign-compare -Wpointer-arith
   -Wformat -Wformat-security -Wno-declaration-after-statement -Wno-vla
   # TODO enable -Wconversion -Wsign-conversion -Wsign-compare
   )
-add_definitions(-pedantic -DPEDANTIC -Werror)
+add_compile_options(-pedantic -Werror)
+add_compile_definitions(-DPEDANTIC)
 
 if(DEFINED ENV{SECUTILS_USE_UTA})
   set(SECUTILS_USE_UTA 1)

--- a/Makefile_v1
+++ b/Makefile_v1
@@ -45,10 +45,10 @@ else
     ifeq ($(shell uname -s),Darwin)
         OS=MacOS
         DLL=.dylib
-        SONAME=install_name
+        SONAME=install_name,@rpath/
     else # assuming Linux
         DLL=.so
-        SONAME=soname
+        SONAME=soname,
     endif
 endif
 
@@ -117,7 +117,10 @@ endif
 override LDFLAGS += $(DEBUG_FLAGS) # needed for -fsanitize=...
 override LDFLAGS += -L $(OPENSSL_LIB) -L $(OPENSSL)
 ifeq ($(DEB_TARGET_ARCH),) # not during Debian packaging
-    override LDFLAGS += -Wl,-rpath $(OPENSSL_LIB) -Wl,-rpath $(OPENSSL) # needed for genCMPClient
+  override LDFLAGS += -Wl,-rpath,$(OPENSSL_LIB)
+  ifneq ($(OPENSSL_LIB),$(OPENSSL))
+    override LDFLAGS += -Wl,-rpath,$(OPENSSL)
+  endif
 endif
 ifneq ($(SECUTILS_USE_UTA),)
     override LDFLAGS += -luta
@@ -201,7 +204,7 @@ endif
 
 # Binary output target
 $(OUT_DIR)/$(OUTLIBV): $(OBJS)
-	$(CC) $(OBJS) $(LDFLAGS) -shared -o $@ -Wl,-$(SONAME),$(OUTLIBV)
+	$(CC) $(OBJS) $(LDFLAGS) -shared -o $@ -Wl,-$(SONAME)$(OUTLIBV)
 
 $(OUT_DIR)/$(OUTLIB): $(OUT_DIR)/$(OUTLIBV)
 	ln -sf $(OUTLIBV) $(OUT_DIR)/$(OUTLIB)

--- a/Makefile_v1
+++ b/Makefile_v1
@@ -276,7 +276,7 @@ clean_uta:
           $(BUILDDIR)/files_dv$(OBJ) \
           $(OUT_DIR)/$(OUTLIB_)*$(DLL)* $(OUT_DIR)/$(OUTBIN) $(OUT_DIR)/util/icvutil.o
 
-clean:
+clean: clean_config
 	rm -fr $(OUT_DIR)/$(OUTLIB_)*$(DLL)*
 	rm -f $(OUT_DIR)/$(OUTBIN)
 	$(MAKE) -C util clean OUT_DIR="$(OUT_DIR)"
@@ -285,7 +285,7 @@ clean:
 clean_config:
 	rm -f $(SECUTILS_CONFIG)
 
-clean_all: clean clean_config clean_deb
+clean_all: clean clean_deb
 	rm -fr Makefile CMakeCache.txt *.cmake CMakeFiles/
 	rm -f install_manifest*.txt
 	rm -fr doc refman.pdf *.gcov reports

--- a/Makefile_v1
+++ b/Makefile_v1
@@ -78,9 +78,9 @@ ifdef NDEBUG
 else
     DEBUG_FLAGS ?= -g -O0 -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all # not every compiler(version) supports -Og
 endif
-override CFLAGS += $(DEBUG_FLAGS) -Wall -Woverflow -Wextra -Wswitch -Wmissing-prototypes -Wstrict-prototypes -Wformat -Wtype-limits -Wundef -Wconversion
-override CFLAGS += -Wno-shadow -Wno-conversion -Wno-sign-conversion -Wno-sign-compare -Wno-unused-parameter # TODO clean up code and enable -Wshadow -Wconversion -Wsign-conversion -Wsign-compare -Wunused-parameter
-override CFLAGS += -Wformat -Wformat-security -Wno-declaration-after-statement -Wno-vla # -Wpointer-arith -pedantic -DPEDANTIC # -Werror
+override CFLAGS += $(DEBUG_FLAGS) -Wall -Woverflow -Wextra -Wswitch -Wmissing-prototypes -Wstrict-prototypes -Wformat -Wformat-security -Wtype-limits -Wundef -Wconversion -Wsign-compare -Wpointer-arith -Wunused-parameter -pedantic -DPEDANTIC
+# TODO clean up code and enable instead:
+override CFLAGS += -Wno-sign-conversion -Wno-shorten-64-to-32 -Wno-c99-extensions -Wno-shadow -Wno-declaration-after-statement -Wno-vla # -Werror
 
 ################################################################################
 # Obligatory flags

--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ Build the software with `make`.
 
 The result is in, for instance, `./libsecutils.so.2.0`.
 
+When getting the linker error: `Undefined symbols: _uta_init_v1`
+likely `secutils_static_config.h` is outdated.  In such situations,
+`make -f Makfile_v1 clean` helps to reset it to a consistent state.
+
 
 ### Installing and uninstalling
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ sudo apt install cmake libssl-dev libc-dev linux-libc-dev
 while `apt install git make gcc` usually is not needed as far as these tools are pre-installed.
 
 
-### Configuring and building
+### Configuring
 
 The library assumes that OpenSSL is already installed,
 including the C header files needed for development
@@ -85,27 +85,6 @@ In case its libraries are in a different location, set also `OPENSSL_LIB`, e.g.:
 export OPENSSL_LIB=$OPENSSL_DIR/lib
 ```
 
-Since version 2, it is recommended to use CMake to produce the `Makefile`,
-for instance as follows:
-```
-cmake .
-```
-
-For backward compatibility it is also possible to use instead of CMake the
-pre-defined [`Makefile_v1`](Makefile_v1); to this end symlink it to `Makefile`:
-```
-ln -s Makefile_v1 Makefile
-```
-or use for instance `make -f Makefile_v1`.
-
-Build the software with `make`.
-
-By default, builds are done in Debug mode.
-For Release mode use `-DCMAKE_BUILD_TYPE=Release` or `NDEBUG=1`.
-For switching to Debug mode, use `-DCMAKE_BUILD_TYPE=Debug` and unset `NDEBUG`.
-
-The result is in, for instance, `./libsecutils.so.2.0`.
-
 Use of the UTA library can be enabled
 by setting the environment variable `SECUTILS_USE_UTA`.
 
@@ -115,8 +94,49 @@ which may be produced using `icvutil`.
 
 The TLS-related functions may be disabled by setting `SECUTILS_NO_TLS`.
 
+Since version 2, it is recommended to use CMake to produce the `Makefile`,
+for instance as follows:
+```
+cmake .
+```
 When using CMake, `cmake` must be (re-)run
 after setting or unsetting environment variables.
+By default, CMake builds are in Release mode.
+This may also be enforced by defining the environment variable `NDEBUG`.
+For switching to Debug mode, use `cmake` with `-DCMAKE_BUILD_TYPE=Debug`.
+The chosen mode is remembered in `CMakeCache.txt`.
+
+For backward compatibility it is also possible to use instead of CMake the
+pre-defined [`Makefile_v1`](Makefile_v1); to this end symlink it to `Makefile`:
+```
+ln -s Makefile_v1 Makefile
+```
+or use for instance `make -f Makefile_v1`.
+
+By default, builds using `Makefile_v1` are in Debug mode.
+Release mode can be selected by defining the environment variable `NDEBUG`.
+
+By default `Makefile_v1` behaves as if
+```
+OPENSSL_DIR=/usr
+```
+was given, such that the OpenSSL headers will be searched for in `/usr/include`
+and its shared objects in `/usr/lib` (or `/usr/bin` for Cygwin).
+
+When using [`Makefile_v1`](Makefile_v1),
+you may also specify using the environment variable `OUT_DIR`
+where the produced library files (e.g., `libcmp.so.2.0`) shall be placed.
+By default, the current directory (`.`) is used.\
+The environment variable `CC` may be set as needed; it defaults to `gcc`.\
+For further details on optional environment variables,
+see the [`Makefile_v1`](Makefile_v1).
+
+
+### Building
+
+Build the software with `make`.
+
+The result is in, for instance, `./libsecutils.so.2.0`.
 
 
 ### Installing and uninstalling

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ and with MacOS.
 
 The following network and development tools are needed or recommended.
 * Git (for getting the software, tested with versions 2.7.2, 2.11.0, 2.20, 2.30.2, 2.39.2)
-* CMake (for using [`CMakeLists.txt`](CMakeLists.txt), tested with versions 3.18.4, 3.26.3, 3.27.0)
+* CMake (for using [`CMakeLists.txt`](CMakeLists.txt), tested with versions 3.18.4, 3.26.3, 3.27.7)
 * GNU make (tested with versions 3.81, 4.1, 4.2.1, 4.3)
 * GNU C compiler (gcc, tested with versions 5.4.0, 7.3.0, 8.3.0, 10.0.1, 10.2.1)
   or clang (tested with version 14.0.3 and 17.0.3)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The following network and development tools are needed or recommended.
 * CMake (for using [`CMakeLists.txt`](CMakeLists.txt), tested with versions 3.18.4, 3.26.3, 3.27.0)
 * GNU make (tested with versions 3.81, 4.1, 4.2.1, 4.3)
 * GNU C compiler (gcc, tested with versions 5.4.0, 7.3.0, 8.3.0, 10.0.1, 10.2.1)
-  or clang (tested with version 14.0.3)
+  or clang (tested with version 14.0.3 and 17.0.3)
 
 The following OSS components are used.
 * OpenSSL development edition, at least version 1.1.1. Tested, among others,

--- a/include/secutils/certstatus/cdp_util.h
+++ b/include/secutils/certstatus/cdp_util.h
@@ -42,7 +42,7 @@ typedef enum CDP_reason_flag {
 typedef int CDP_REASON_FLAGS;
 
 /* Copy a one-line representation of the X509_NAME into the buffer */
-int CDP_get_x509_name(
+bool CDP_get_x509_name(
     X509_NAME       *name,
     char            *name_utf8_buf,
     size_t          name_utf8_buf_len,
@@ -50,7 +50,7 @@ int CDP_get_x509_name(
 );
 
 /* Copy the ASN1 time into a string */
-int CDP_get_x509_time(
+bool CDP_get_x509_time(
     const ASN1_TIME *time,
     char            *name_utf8_buf,
     size_t          name_utf8_buf_len
@@ -85,10 +85,8 @@ const char *CDP_get_crl_distribution_point_from_extension(
 );
 
 /* Get the CDP url from an X509 certificate structure.
- * Return a const char * pointer to the internal data.
- * The pointer is valid only as long as the cert
- * parameter given is not freed.*/
-int CDP_get_crl_distribution_point_from_cert(
+ * Return true if CDP url is present and was copied successfully */
+bool CDP_get_crl_distribution_point_from_cert(
     const X509  *cert,
     int         nid,
     char        *cdp_utf8_buf,

--- a/include/secutils/certstatus/crl_mgmt.h
+++ b/include/secutils/certstatus/crl_mgmt.h
@@ -110,10 +110,11 @@ const char *CRLMGMT_DATA_get_crl_cache_dir(
 );
 
 /*!
- * @brief The function sets the cache directory in the CRL management context.
+ * @brief The function sets or clears the cache directory in the CRL management context.
  * @note  The directory name is not copied into the structure. Therefore the
  *        parameter cache directory must exist during the lifetime of the context.
- *        If not null, it must end with the (potentially platform-specific) path separator.
+ *        The directory name may be null to clear the entry.
+ *        It does does not need to end with the path name separator.
  *
  * @param cmdat pointer to the CRL management data structure
  * @param crl_cache_dir the cache directory

--- a/include/secutils/util/util.h
+++ b/include/secutils/util/util.h
@@ -331,17 +331,16 @@ bool UTIL_get_random(void *buf, size_t len);
  * @param source pointer to the unencoded source string
  * @param destination optional pointer to destination buffer to hold the result
  * @param destination_len size of the destination buffer in bytes
- * @param size_needed optional pointer to the exact size needed for the
- *        converted string. If the size_needed is null the size is not returned
+ * @param size_needed optional pointer to the exact size (including the terminating NUL) that
+ *        is needed for the copied string. If the size_needed is null the size is not returned.
  *
- * @return number of bytes excluding the terminating NUL that have been written
- *             into the destination buffer.
- *         0 also on fatal error, e.g., the source is null
- *         or the destination is not null and the buffer size is 0.
+ * @return number of bytes excluding the terminating NUL that have been copied to destination,
+ *         -1 on error, e.g., the source is null or
+ *            the destination is not null and the buffer size is 0.
  */
-size_t UTIL_safe_string_copy(const char *source, OPTIONAL char *destination,
-                             size_t destination_len,
-                             OPTIONAL size_t *size_needed);
+int UTIL_safe_string_copy(const char *source, OPTIONAL char *destination,
+                          size_t destination_len,
+                          OPTIONAL size_t *size_needed);
 
 /*!
  * @brief The function URL-encodes the source string in the destination buffer.

--- a/src/certstatus/crl_mgmt.c
+++ b/src/certstatus/crl_mgmt.c
@@ -81,6 +81,10 @@ static bool get_cache_filename_from_url(const char * cache_dir, const char * url
         return false;
     }
     size_t len = (size_t)res;
+    if (buflen > len + 1 && buf[len] != '/' && buf[len] != '\\') {
+        buf[len] = '/'; /* add missing path name separator */
+        buf[++len] = '\0';
+    }
 
     // create sha256 from url
     unsigned char hash[SHA256_DIGEST_LENGTH];

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -53,7 +53,7 @@ static bool parse_long(const char* str, long* result)
     return true;
 }
 
-CONF* CONF_load_config(OPTIONAL uta_ctx* ctx, const char* file)
+CONF* CONF_load_config(OPTIONAL ossl_unused uta_ctx* ctx, const char* file)
 {
     CONF* conf = 0;
 

--- a/src/config/config_update.c
+++ b/src/config/config_update.c
@@ -298,7 +298,7 @@ static int copy_remaining_config(FILE* file_p, int file_len, char* input_line)
 
 
 /* returns length of new file, or 0 in case of error */
-int CONF_update_config(OPTIONAL uta_ctx* ctx, const char* file_name, const key_val_section* key_val_section,
+int CONF_update_config(OPTIONAL ossl_unused uta_ctx* ctx, const char* file_name, const key_val_section* key_val_section,
                        int exclude)
 {
     FILE* file_p = 0;
@@ -373,7 +373,7 @@ int CONF_update_config(OPTIONAL uta_ctx* ctx, const char* file_name, const key_v
             goto error;
         }
 
-        if(fprintf(file_p, "%s", file_buffer) not_eq file_len)
+        if((size_t)fprintf(file_p, "%s", file_buffer) not_eq file_len)
         {
             file_len = 0;
             LOG(FL_ERR, "Error writing config file '%s'", file_name);

--- a/src/credentials/key.c
+++ b/src/credentials/key.c
@@ -265,7 +265,7 @@ EVP_PKEY* KEY_new(const char* spec)
 #if OPENSSL_VERSION_NUMBER >= OPENSSL_V_3_0_0
         pkey = EVP_EC_gen(OSSL_EC_curve_nid2name(nid));
         if (pkey == NULL) {
-            LOG(FL_ERR, "cannot generate EC key with curve name %.40%s", spec);
+            LOG(FL_ERR, "cannot generate EC key with curve name %.40s", spec);
             goto err;
         }
         return pkey;

--- a/src/credentials/store.c
+++ b/src/credentials/store.c
@@ -49,8 +49,8 @@ static
 #else
        void
 #endif
-STORE_EX_new(X509_STORE* ts, STORE_EX* ex_data, CRYPTO_EX_DATA* ad,
-                         int idx, long argl, void* argp)
+STORE_EX_new(X509_STORE* ts, STORE_EX* ex_data, ossl_unused CRYPTO_EX_DATA* ad,
+                         int idx, ossl_unused long argl, ossl_unused void* argp)
 {
     int res = 1;
     if((ex_data = OPENSSL_zalloc(sizeof(*ex_data))) is_eq 0)
@@ -73,8 +73,8 @@ STORE_EX_new(X509_STORE* ts, STORE_EX* ex_data, CRYPTO_EX_DATA* ad,
 #endif
 }
 
-static void STORE_EX_free(X509_STORE* ts, STORE_EX* ex_data, CRYPTO_EX_DATA* ad,
-                          int idx, long argl, void* argp)
+static void STORE_EX_free(ossl_unused X509_STORE* ts, STORE_EX* ex_data, ossl_unused CRYPTO_EX_DATA* ad,
+                          ossl_unused int idx, ossl_unused long argl, ossl_unused void* argp)
 {
     if(0 not_eq ex_data)
     {

--- a/src/credentials/verify.c
+++ b/src/credentials/verify.c
@@ -186,7 +186,7 @@ bool verify_cb_cert(X509_STORE_CTX* store_ctx, X509* cert, int err)
     return verify_cb != 0 and (*verify_cb)(0, store_ctx) != 0;
 }
 
-int CREDENTIALS_verify_cert(OPTIONAL uta_ctx* uta_ctx, X509* cert,
+int CREDENTIALS_verify_cert(OPTIONAL ossl_unused uta_ctx* uta_ctx, X509* cert,
                             OPTIONAL const STACK_OF(X509) * untrusted_certs, X509_STORE* trust_store)
 {
     int result = -1;

--- a/src/crypto/crypto.c
+++ b/src/crypto/crypto.c
@@ -63,7 +63,7 @@ EVP_CIPHER_CTX* AESGCM_init(const uint8_t* key, size_t key_len, const uint8_t* i
     }
 
     int key_len_req = EVP_CIPHER_CTX_key_length(osslctx);
-    if(key_len_req != key_len)
+    if((size_t)key_len_req != key_len)
     {
         LOG(FL_ERR, "Length of provided key doesn't match required by cipher (%d != %d)",
                 key_len, key_len_req);
@@ -93,8 +93,8 @@ ssize_t AESGCM_encrypt(EVP_CIPHER_CTX* osslctx, uint8_t* cipher_buff, size_t cip
         return ret;
     }
 
-    int32_t cipher_len = cipher_buff_len;
-    if((EVP_EncryptUpdate(osslctx, cipher_buff, &cipher_len, plain, plain_len) not_eq 1) or (cipher_len not_eq plain_len))
+    int cipher_len = cipher_buff_len;
+    if((EVP_EncryptUpdate(osslctx, cipher_buff, &cipher_len, plain, plain_len) not_eq 1) or ((size_t)cipher_len not_eq plain_len))
     {/* The second condition - GCM is used, hence length(plain_text) == length(cipher_text) */
         LOG(FL_ERR, "Encryption failed");
         return ret;
@@ -117,9 +117,9 @@ ssize_t AESGCM_decrypt(EVP_CIPHER_CTX* osslctx, uint8_t* plain_buff, size_t plai
         return ret;
     }
 
-    int32_t plain_len = plain_buff_len;
+    int plain_len = plain_buff_len;
     if((EVP_DecryptUpdate(osslctx, plain_buff, &plain_len, cipher, cipher_len) not_eq 1)
-            or (plain_len not_eq cipher_len))
+       or ((size_t)plain_len not_eq cipher_len))
     {/* The second condition - GCM is used hence length(plain_text) == length(cipher_text) */
         LOG(FL_ERR, "Decryption failed");
         return ret;

--- a/src/storage/files_dv.c
+++ b/src/storage/files_dv.c
@@ -433,7 +433,7 @@ EVP_PKEY* FILES_load_key_autofmt_dv(const char* key, file_format_t file_format, 
         }
         else
         {
-            return false;
+            return 0;
         }
     }
     pkey = FILES_load_key_autofmt(key, file_format, false /* no stdin */, source, engine, desc);
@@ -458,7 +458,7 @@ STACK_OF(X509)
         }
         else
         {
-            return false;
+            return 0;
         }
     }
     certs = FILES_load_certs_autofmt(file, format, source, desc);

--- a/src/util/log.c
+++ b/src/util/log.c
@@ -259,9 +259,8 @@ bool LOG_system_debug(int errnum)
     errno = 0;
 
     // https://man7.org/linux/man-pages/man3/strerror.3.html : RETURN VALUE
-    const char *message = "";
-    message = strerror_r(errnum, buffer, sizeof(buffer));
-    bool result = 0 is_eq errno;
+    bool result = 0 is_eq strerror_r(errnum, buffer, sizeof(buffer))
+        and 0 is_eq errno;
 
     if (ERANGE is_eq errno)
     {
@@ -269,7 +268,7 @@ bool LOG_system_debug(int errnum)
         (void)memcpy((void *)(buffer + (sizeof(buffer) - sizeof(messageTooLong))), (const void *)messageTooLong, sizeof(messageTooLong));
     }
 
-    result = result and LOG(FL_DEBUG, "system error info: 'errno' = %i, '%s'", errnum, message);
+    result = result and LOG(FL_DEBUG, "system error info: 'errno' = %i, '%s'", errnum, buffer);
 
     // must stay after calling LOG; LOG may change errno
     errno = errnoBak;

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -102,7 +102,7 @@ void* UTIL_read_file(const char* filename, int* lenp)
     FILE* fp = 0;
     struct stat st;
     unsigned char* contents = 0;
-    int contents_len = 0;
+    unsigned long contents_len = 0;
 
     if(stat(filename, &st) < 0)
     {
@@ -143,7 +143,7 @@ end:
     }
     if(0 not_eq lenp)
     {
-        *lenp = contents_len;
+        *lenp = (int)contents_len;
     }
     return contents;
 }
@@ -511,7 +511,7 @@ size_t UTIL_bintohex(
 
 bool UTIL_hex_to_bytes(const char** in_p, unsigned char* out, unsigned int num_out)
 {
-    unsigned int v = 0;
+    unsigned char v = 0;
     unsigned int i = 0;
     unsigned char byte = 0;
 


### PR DESCRIPTION
Various fixes for the build system regarding CMake, the Makefiles, support of MacOS, compiler warnings.

This switches the default CMake build mode to Release, as suggested by @xsulca00.

Small bug fixes:
* util/log.c: fix use of strerror_r() result in LOG_system_debug()
* CRLMGMT_DATA_set_crl_cache_dir(): allow crl_cache_dir without separator '/' at dir path end
* UTIL_safe_string_copy(): improve code and doc; check for error when calling it; fix CDP API
* KEY_new(): fix curve name output in error message