### PR TITLE
check_cert_crls(): fix missing copy behavior for X.509v3 extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,13 +171,14 @@ The recommended way is to use CPack with the files produced by CMake as follows:
 ```
 make deb
 ```
+which requries the `file` utility.
 
 Alternatively, [`Makefile_v1`](Makefile_v1) may be used like this:
 ```
 make -f Makefile_v1 deb
 ```
 In this case, the resulting packages are placed in the parent directory (`../`),
-and following dependencies need to be installed:
+and requires the following Debian packages:
 * `debhelper` (needed for `dh`)
 * `devscripts` (needed for `debuild`)
 * `libssl-dev`


### PR DESCRIPTION
This was leading to needless failure, even with misleading reason `X509_V_ERR_DIFFERENT_CRL_SCOPE`