### PR TITLE
Fix sloppy code mixing `int` and `size_t` after `cc1` no more supporting `-Wno-shorten-64-to-32`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ if(DEFINED ENV{NDEBUG} OR NOT CMAKE_BUILD_TYPE MATCHES Debug)
   set(CMAKE_BUILD_TYPE Release
       CACHE STRING "Choose the type of build." FORCE)
   add_compile_options(-O2)
-  add_compile_definitions(-DNDEBUG=1)
+  add_compile_definitions(NDEBUG=1)
 else()
   set(CMAKE_BUILD_TYPE Debug
       CACHE STRING "Choose the type of build." FORCE)
@@ -132,7 +132,7 @@ add_compile_options( # TODO clean up code and re-enable warnings instead:
   -Wno-shadow -Wno-declaration-after-statement -Wno-vla
   )
 add_compile_options(-pedantic -Werror)
-add_compile_definitions(-DPEDANTIC)
+add_compile_definitions(PEDANTIC)
 
 if(DEFINED ENV{SECUTILS_USE_UTA})
   set(SECUTILS_USE_UTA 1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,8 +127,8 @@ add_compile_options(
   -Wall -Woverflow -Wextra -Wswitch -Wmissing-prototypes -Wstrict-prototypes
   -Wformat -Wformat-security -Wtype-limits -Wundef -Wconversion
   -Wsign-compare -Wpointer-arith -Wunused-parameter)
-add_compile_options( # TODO clean up code and enable instead:
-  -Wsign-conversion -Wno-shorten-64-to-32 -Wno-c99-extensions
+add_compile_options( # TODO clean up code and re-enable warnings instead:
+  -Wsign-conversion -Wno-c99-extensions
   -Wno-shadow -Wno-declaration-after-statement -Wno-vla
   )
 add_compile_options(-pedantic -Werror)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,7 @@ endif()
 configure_file(${INC_DIR}/secutils_static_config.h.in
                ${INC_DIR}/secutils_static_config.h)
 
+# TODO clean up code and re-enable property
 # set_property(TARGET ${LIBSECUTILS_NAME} PROPERTY C_STANDARD 90)
 
 target_link_libraries(${LIBSECUTILS_NAME} ${OPENSSL_LIBRARIES}) # needed for clang/MacOSX

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,10 +40,10 @@ message(STATUS "build mode: ${CMAKE_BUILD_TYPE}")
 
 add_compile_options(
   -Wall -Woverflow -Wextra -Wswitch -Wmissing-prototypes -Wstrict-prototypes
-  -Wformat -Wformat-security -Wtype-limits -Wundef -Wconversion
+  -Wformat -Wformat-security -Wtype-limits -Wundef
   -Wsign-compare -Wpointer-arith -Wunused-parameter)
 add_compile_options( # TODO clean up code and re-enable warnings instead:
-  -Wsign-conversion -Wno-c99-extensions
+  -Wno-conversion -Wno-sign-conversion
   -Wno-shadow -Wno-declaration-after-statement -Wno-vla
   )
 add_compile_options(-pedantic -Werror)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,35 @@ else()
 endif()
 include(GNUInstallDirs) # CMAKE_INSTALL_PREFIX must be set before
 
+# add_compile_options must be set before add_library
+if(DEFINED ENV{NDEBUG} OR NOT CMAKE_BUILD_TYPE MATCHES Debug)
+  set(CMAKE_BUILD_TYPE Release
+      CACHE STRING "Choose the type of build." FORCE)
+  add_compile_options(-O2)
+  add_compile_definitions(NDEBUG=1)
+else()
+  set(CMAKE_BUILD_TYPE Debug
+      CACHE STRING "Choose the type of build." FORCE)
+  add_compile_options(-g -O0)
+
+  set(DEBUG_FLAGS "-fsanitize=address,undefined -fno-sanitize-recover=all") # must use quotes on MacOSX
+  add_compile_options(${DEBUG_FLAGS})
+  link_libraries(${DEBUG_FLAGS})
+  set(CMAKE_SHARED_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS} ${DEBUG_FLAGS}) # workarund for link_libraries() ignored on MacOSX
+endif()
+message(STATUS "build mode: ${CMAKE_BUILD_TYPE}")
+
+add_compile_options(
+  -Wall -Woverflow -Wextra -Wswitch -Wmissing-prototypes -Wstrict-prototypes
+  -Wformat -Wformat-security -Wtype-limits -Wundef -Wconversion
+  -Wsign-compare -Wpointer-arith -Wunused-parameter)
+add_compile_options( # TODO clean up code and re-enable warnings instead:
+  -Wsign-conversion -Wno-c99-extensions
+  -Wno-shadow -Wno-declaration-after-statement -Wno-vla
+  )
+add_compile_options(-pedantic -Werror)
+add_compile_definitions(PEDANTIC)
+
 if(NOT("$ENV{OPENSSL_DIR}" STREQUAL ""))
   message(STATUS "using OpenSSL from " $ENV{OPENSSL_DIR})
   if(DEFINED ENV{OPENSSL_LIB})
@@ -105,34 +134,6 @@ set(INC_PUBLIC_HDRS
 )
 
 include_directories(${INC_DIR}/.. ${INC_DIR})
-
-if(DEFINED ENV{NDEBUG} OR NOT CMAKE_BUILD_TYPE MATCHES Debug)
-  set(CMAKE_BUILD_TYPE Release
-      CACHE STRING "Choose the type of build." FORCE)
-  add_compile_options(-O2)
-  add_compile_definitions(NDEBUG=1)
-else()
-  set(CMAKE_BUILD_TYPE Debug
-      CACHE STRING "Choose the type of build." FORCE)
-  add_compile_options(-g -O0)
-
-  set(DEBUG_FLAGS "-fsanitize=address,undefined -fno-sanitize-recover=all") # must use quotes on MacOSX
-  add_compile_options(${DEBUG_FLAGS})
-  link_libraries(${DEBUG_FLAGS})
-  set(CMAKE_SHARED_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS} ${DEBUG_FLAGS}) # workarund for link_libraries() ignored on MacOSX
-endif()
-message(STATUS "build mode: ${CMAKE_BUILD_TYPE}")
-
-add_compile_options(
-  -Wall -Woverflow -Wextra -Wswitch -Wmissing-prototypes -Wstrict-prototypes
-  -Wformat -Wformat-security -Wtype-limits -Wundef -Wconversion
-  -Wsign-compare -Wpointer-arith -Wunused-parameter)
-add_compile_options( # TODO clean up code and re-enable warnings instead:
-  -Wsign-conversion -Wno-c99-extensions
-  -Wno-shadow -Wno-declaration-after-statement -Wno-vla
-  )
-add_compile_options(-pedantic -Werror)
-add_compile_definitions(PEDANTIC)
 
 if(DEFINED ENV{SECUTILS_USE_UTA})
   set(SECUTILS_USE_UTA 1)

--- a/Makefile_v1
+++ b/Makefile_v1
@@ -78,9 +78,13 @@ ifdef NDEBUG
 else
     DEBUG_FLAGS ?= -g -O0 -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all # not every compiler(version) supports -Og
 endif
-override CFLAGS += $(DEBUG_FLAGS) -Wall -Woverflow -Wextra -Wswitch -Wmissing-prototypes -Wstrict-prototypes -Wformat -Wformat-security -Wtype-limits -Wundef -Wconversion -Wsign-compare -Wpointer-arith -Wunused-parameter
+override CFLAGS += $(DEBUG_FLAGS) \
+ -Wall -Woverflow -Wextra -Wswitch -Wmissing-prototypes -Wstrict-prototypes \
+ -Wformat -Wformat-security -Wtype-limits -Wundef \
+ -Wsign-compare -Wpointer-arith -Wunused-parameter
 # TODO clean up code and re-enable warnings instead:
-override CFLAGS += -Wno-sign-conversion -Wno-c99-extensions -Wno-shadow -Wno-declaration-after-statement -Wno-vla
+override CFLAGS += -Wno-conversion -Wno-sign-conversion \
+ -Wno-shadow -Wno-declaration-after-statement -Wno-vla
 override CFLAGS += -pedantic -DPEDANTIC -Werror
 
 ################################################################################

--- a/Makefile_v1
+++ b/Makefile_v1
@@ -104,7 +104,7 @@ DEST_INC=$(DEST_PRE)
 DEST_DOC=$(DEST_PRE)/share/doc/libsecutils-dev
 OUTBIN=icvutil$(EXE)
 DEST_BIN=$(DEST_PRE)/bin
-LOCAL_CFLAGS=-std=gnu90 -fPIC
+LOCAL_CFLAGS= -fPIC # -std=gnu90 TODO clean up code and re-enable flag
 override CFLAGS += -isystem $(OPENSSL)/include# # # use of -isystem is critical for selecting wanted OpenSSL version
 override CFLAGS += -Iinclude
 override CFLAGS += -Iinclude/secutils

--- a/Makefile_v1
+++ b/Makefile_v1
@@ -78,9 +78,10 @@ ifdef NDEBUG
 else
     DEBUG_FLAGS ?= -g -O0 -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all # not every compiler(version) supports -Og
 endif
-override CFLAGS += $(DEBUG_FLAGS) -Wall -Woverflow -Wextra -Wswitch -Wmissing-prototypes -Wstrict-prototypes -Wformat -Wformat-security -Wtype-limits -Wundef -Wconversion -Wsign-compare -Wpointer-arith -Wunused-parameter -pedantic -DPEDANTIC
-# TODO clean up code and enable instead:
-override CFLAGS += -Wno-sign-conversion -Wno-shorten-64-to-32 -Wno-c99-extensions -Wno-shadow -Wno-declaration-after-statement -Wno-vla # -Werror
+override CFLAGS += $(DEBUG_FLAGS) -Wall -Woverflow -Wextra -Wswitch -Wmissing-prototypes -Wstrict-prototypes -Wformat -Wformat-security -Wtype-limits -Wundef -Wconversion -Wsign-compare -Wpointer-arith -Wunused-parameter
+# TODO clean up code and re-enable warnings instead:
+override CFLAGS += -Wno-sign-conversion -Wno-c99-extensions -Wno-shadow -Wno-declaration-after-statement -Wno-vla
+override CFLAGS += -pedantic -DPEDANTIC -Werror
 
 ################################################################################
 # Obligatory flags

--- a/include/secutils/certstatus/crl_mgmt.h
+++ b/include/secutils/certstatus/crl_mgmt.h
@@ -264,4 +264,4 @@ X509_CRL *CRLMGMT_load_crl_cb(
 # ifdef  __cplusplus
 }
 # endif
-#endif // SECUTILS_HEADER_CRL_MGMT_H
+#endif /* SECUTILS_HEADER_CRL_MGMT_H */

--- a/src/certstatus/cdp_util.c
+++ b/src/certstatus/cdp_util.c
@@ -153,8 +153,8 @@ const char *CDP_get_crl_distribution_point_from_distpoint(
              */
 #if 0 /* ignored */
             const STACK_OF(X509_NAME_ENTRY) *relNames = point->distpoint->name.relativename;
-            // X509_NAME_print_ex(out, &ntmp, 0, XN_FLAG_ONELINE);
-            // TODO: add issuer and handle more relative name stuff
+            /* X509_NAME_print_ex(out, &ntmp, 0, XN_FLAG_ONELINE); */
+            /* TODO: add issuer and handle more relative name stuff */
             int j;
             for (j = 0; j < sk_X509_NAME_ENTRY_num(relNames); ++j) {
                 X509_NAME_ENTRY *entry  = sk_X509_NAME_ENTRY_value(relNames, j);

--- a/src/certstatus/crl_mgmt.c
+++ b/src/certstatus/crl_mgmt.c
@@ -1,13 +1,13 @@
-/** 
+/**
 * @file crl_mgmt.c
-* 
+*
 * @brief Handling CRLs during certificate revocation check
 *
 * @copyright Copyright (c) Siemens Mobility GmbH, 2021
 *
 * @author David von Oheimb <david.von.oheimb@siemens.com>
 *
-* This work is licensed under the terms of the Apache Software License 
+* This work is licensed under the terms of the Apache Software License
 * 2.0. See the COPYING file in the top-level directory.
 *
 * SPDX-License-Identifier: Apache-2.0
@@ -52,11 +52,11 @@ static int nidCrlNextPublish            = 0;
 static bool chkmkdir(const char *dir) {
     struct stat s;
     if (stat(dir, &s) == 0) {
-        // ok path exists, check, if it is a dir
+        /* ok path exists, check, if it is a dir */
         return S_ISDIR(s.st_mode) != 0;
     }
     if (errno == ENOENT) {
-        // path is not existing
+        /* path is not existing */
         return mkdir(dir, 0700) == 0;
     }
     return false;
@@ -86,7 +86,7 @@ static bool get_cache_filename_from_url(const char * cache_dir, const char * url
         buf[++len] = '\0';
     }
 
-    // create sha256 from url
+    /* create sha256 from url */
     unsigned char hash[SHA256_DIGEST_LENGTH];
     SHA256((unsigned char*)url, strlen(url), hash);
     len += UTIL_bintohex(hash, SHA256_DIGEST_LENGTH, false, 0, 0, buf+len, buflen-len, NULL);
@@ -108,12 +108,14 @@ static X509_CRL *get_crl_from_cache(const char * cachefile)
 
     in = BIO_new_file(cachefile, "rb");
     if (in != NULL) {
-        // read crl from ASN1 format
+        /* read crl from ASN1 format */
         crl = d2i_X509_CRL_bio(in, NULL);
-        // the PEM format would be this, format detection is currently not supported
-        // crl = PEM_read_bio_X509_CRL(in, NULL, NULL, NULL);
+        /*
+         * the PEM format would be this, format detection is currently not supported
+         * crl = PEM_read_bio_X509_CRL(in, NULL, NULL, NULL);
+         */
         if (crl == NULL) {
-            // do not unlink an unknown file that is not loadable as CRL
+            /* do not unlink an unknown file that is not loadable as CRL */
             LOG(FL_ERR, "error loading the CRL from cache file: %s", cachefile);
         }
         BIO_free(in);
@@ -170,10 +172,10 @@ static X509_CRL *get_crl_from_cache(const char * cachefile)
         LOG(FL_TRACE, "CRL timecheck: isBeforeStart: %d, isAfterEnd: %d, isAfterPublish: %d", isBeforeStart, isAfterEnd, isAfterPublish);
         if (isBeforeStart || isAfterEnd || isAfterPublish) {
             LOG(FL_DEBUG, "CRL is expired, so deleting it from the cache");
-            // crl not within time frame, remove it
+            /* crl not within time frame, remove it */
             X509_CRL_free(crl);
             crl = NULL;
-            // unlink the expired CRL file
+            /* unlink the expired CRL file */
             unlink(cachefile);
         }
         else {
@@ -191,10 +193,12 @@ static int put_crl_into_cache(X509_CRL * crl, const char * cachefile)
 
     BIO *out = BIO_new_file(cachefile, "wb");
     if (out != NULL) {
-        // write the CRL into an ASN1 formatted file
+        /* write the CRL into an ASN1 formatted file */
         res = (int)i2d_X509_CRL_bio(out, crl);
-        // PEM format would be this, different formats are currently not supported
-        // res = PEM_write_bio_X509_CRL(out, crl);
+        /*
+         * PEM format would be this, different formats are currently not supported
+         * res = PEM_write_bio_X509_CRL(out, crl);
+         */
         if (!res) {
             BIO_printf(bio_err, "unable to write CRL\n");
         }
@@ -234,7 +238,7 @@ static X509_CRL *get_crl_by_download_or_from_cache(const CRLMGMT_DATA *data,
 CRLMGMT_DATA *CRLMGMT_DATA_new(void)
 {
     if (nidCrlNextPublish==0) {
-        // TODO this is not thread-safe
+        /* TODO this is not thread-safe */
         nidCrlNextPublish = OBJ_create("1.3.6.1.4.1.311.21.4",
             SN_crl_next_publish, LN_crl_next_publish);
     }

--- a/src/certstatus/ocsp.c
+++ b/src/certstatus/ocsp.c
@@ -349,7 +349,11 @@ int ocsp_stapling_cb(SSL* ssl, OPTIONAL STACK_OF(X509) *untrusted)
         {
             LOG(FL_ERR, "error parsing stapled OCSP response");
             /* well, this is likely not an internal error (malloc failure) */
-            BIO_dump_indent(bio_trace, resp_der, (int)resp_der_len, 4);
+            BIO_dump_indent(bio_trace,
+#  if OPENSSL_VERSION_NUMBER < 0x30000000L
+                            (char *)
+#  endif
+                            resp_der, (int)resp_der_len, 4);
             BIO_flush(bio_trace);
             goto end;
         }

--- a/src/config/config_update.c
+++ b/src/config/config_update.c
@@ -107,7 +107,7 @@ static size_t refactor_entry(char *src_p, char *dest_p, const char *const key_p,
         pos_p--;
     }
     if(pos_p < pos_start || (size_t)(pos_p - pos_start) != val_len
-       || strncmp(pos_start, val_p, val_len))
+       || strncmp(pos_start, val_p, val_len) not_eq 0)
     {
         file_modified = 1;
     }
@@ -183,7 +183,7 @@ static size_t read_config_until_section(FILE* file_p, const char* file_name, con
         LOG(FL_ERR, "Cannot find section '%s' in config file '%s'", section_name, file_name);
         return 0;
     }
-    return file_len;
+    return file_len; /* TODO check: file_len is always 0 */
 }
 
 
@@ -209,7 +209,7 @@ static size_t add_to_config_section(size_t file_len, const key_val_section* cons
         }
     }
 
-    return file_len;
+    return file_len; /* TODO check: file_len is not updated */
 }
 
 
@@ -297,11 +297,12 @@ static size_t copy_remaining_config(FILE *file_p, size_t file_len,
         line_len = strnlen(input_line, c_line_buf_size);
         copy_file_line(file_buffer, input_line, line_len);
     }
-    return file_len;
+    return file_len; /* TODO check: file_len is not updated */
 }
 
 
 /* returns length of new file, or 0 in case of error */
+/* TODO check: return value is always 0 */
 int CONF_update_config(OPTIONAL ossl_unused uta_ctx* ctx, const char* file_name, const key_val_section* key_val_section,
                        int exclude)
 {
@@ -391,7 +392,7 @@ int CONF_update_config(OPTIONAL ossl_unused uta_ctx* ctx, const char* file_name,
             return 0;
         }
 #endif
-        return (int)file_len;
+        return (int)file_len; /* TODO check: file_len is always 0 */
     }
     else
     {

--- a/src/config/config_update.c
+++ b/src/config/config_update.c
@@ -29,9 +29,10 @@ static void skip_space(char** p)
 }
 
 
-static bool copy_line_substring(char* dest, const char* src, int* offset, int max_dest_len)
+static bool copy_line_substring(char *dest, const char *src,
+                                size_t *offset, size_t max_dest_len)
 {
-    int copy_len = strnlen(src, max_dest_len);
+    size_t copy_len = strnlen(src, max_dest_len);
     if(*offset + copy_len > max_dest_len)
     {
         return false;
@@ -51,9 +52,10 @@ static int file_modified;
  * Keeps any end-of-line comment.
  * Returns the length of the resulting line, or 0 in case of error.
  */
-static int refactor_entry(char* src_p, char* dest_p, const char* const key_p, const char* const val_p, int max_dest_len)
+static size_t refactor_entry(char *src_p, char *dest_p, const char *const key_p,
+                             const char *const val_p, size_t max_dest_len)
 {
-    int line_len = 0;
+    size_t line_len = 0;
     char* pos_p = src_p;
 
     if(0 is_eq src_p or 0 is_eq key_p or 0 is_eq val_p)
@@ -82,7 +84,7 @@ static int refactor_entry(char* src_p, char* dest_p, const char* const key_p, co
     skip_space(&pos_p);
 
     /* found "key = ", copy in the new value */
-    int val_len = strnlen(val_p, max_dest_len);
+    size_t val_len = strnlen(val_p, max_dest_len);
     line_len = pos_p - src_p;
     if(not copy_line_substring(dest_p, val_p, &line_len, max_dest_len))
     {
@@ -104,7 +106,8 @@ static int refactor_entry(char* src_p, char* dest_p, const char* const key_p, co
     {
         pos_p--;
     }
-    if(pos_p - pos_start not_eq val_len or strncmp(pos_start, val_p, val_len))
+    if(pos_p < pos_start || (size_t)(pos_p - pos_start) != val_len
+       || strncmp(pos_start, val_p, val_len))
     {
         file_modified = 1;
     }
@@ -151,11 +154,11 @@ static size_t read_config_until_section(FILE* file_p, const char* file_name, con
 {
     size_t file_len = 0;
     char* pos_p = 0;
-    int section_name_len = strlen(section_name);
+    size_t section_name_len = strlen(section_name);
     LOG(FL_TRACE, "Reading configuration until section is found or end of file reached");
     while(0 not_eq fgets(input_line, c_line_buf_size, file_p))
     {
-        int line_len = strnlen(input_line, c_line_buf_size);
+        size_t line_len = strnlen(input_line, c_line_buf_size);
         copy_file_line(file_buffer, input_line, line_len);
 
         /* break if line matches "\ *\[\ *section_name\ *\]" */
@@ -221,7 +224,7 @@ static size_t update_config_section(FILE* file_p, const char* file_name, size_t 
     LOG(FL_TRACE, "Replacing 'key = value' pairs in the section");
     while(0 not_eq fgets(input_line, c_line_buf_size, file_p))
     {
-        int line_len = strnlen(input_line, c_line_buf_size);
+        size_t line_len = strnlen(input_line, c_line_buf_size);
         if(line_len > c_line_buf_size - 1)
         {
             return 0;
@@ -283,9 +286,10 @@ static size_t update_config_section(FILE* file_p, const char* file_name, size_t 
 
 
 /* copy the rest of the file into the buffer */
-static int copy_remaining_config(FILE* file_p, int file_len, char* input_line)
+static size_t copy_remaining_config(FILE *file_p, size_t file_len,
+                                    char *input_line)
 {
-    int line_len = strnlen(input_line, c_line_buf_size); /* first line of next section already read */
+    size_t line_len = strnlen(input_line, c_line_buf_size); /* first line of next section already read */
     copy_file_line(file_buffer, input_line, line_len);
 
     while(0 not_eq fgets(input_line, c_line_buf_size, file_p))
@@ -387,7 +391,7 @@ int CONF_update_config(OPTIONAL ossl_unused uta_ctx* ctx, const char* file_name,
             return 0;
         }
 #endif
-        return file_len;
+        return (int)file_len;
     }
     else
     {

--- a/src/connections/conn.c
+++ b/src/connections/conn.c
@@ -120,7 +120,7 @@ char* CONN_get_host(const char* uri)
         {
             end = strchr(uri, '/');
         }
-        int len = end not_eq 0 ? end - uri : strlen(uri);
+        size_t len = end not_eq 0 ? (size_t)(end - uri) : strlen(uri);
         str = OPENSSL_strndup(uri, len);
         if(0 is_eq str)
         {

--- a/src/credentials/store.c
+++ b/src/credentials/store.c
@@ -451,7 +451,7 @@ bool STORE_load_crl_dir(X509_STORE* pstore, const char* crl_dir, OPTIONAL const 
         p_dirent = readdir(p_dir);
     }
 
-    // set up cert CRL check callback for checking full chain
+    /* set up cert CRL check callback for checking full chain */
     if(found)
     {
         X509_VERIFY_PARAM_set_flags(X509_STORE_get0_param(pstore), X509_V_FLAG_STATUS_CHECK_ALL);

--- a/src/credentials/verify.c
+++ b/src/credentials/verify.c
@@ -31,6 +31,7 @@ bool STORE_CTX_tls_active(const X509_STORE_CTX* ctx)
 #ifndef SECUTILS_NO_TLS
     return X509_STORE_CTX_get_ex_data((X509_STORE_CTX*)ctx, SSL_get_ex_data_X509_STORE_CTX_idx()) not_eq 0;
 #else
+    (void)ctx; /* prevent compiler warning on unused variable */
     return false;
 #endif
 }

--- a/src/storage/files_dv.c
+++ b/src/storage/files_dv.c
@@ -104,7 +104,7 @@ static bool store_dv(OPTIONAL uta_ctx* ctx, const char* dvfile, const char* name
         }
         int file_len = fprintf(fp, "[%s]\n", DV_SECTION);
         fclose(fp);
-        if(file_len not_eq strlen("[") + strlen(DV_SECTION) + strlen("]") + 1)
+        if(file_len not_eq (int)(strlen("[") + strlen(DV_SECTION) + strlen("]") + 1))
         {
             LOG(FL_ERR, "Error writing initial DV file '%s'", dvfile);
             return false;

--- a/src/storage/files_icv.c
+++ b/src/storage/files_icv.c
@@ -152,7 +152,7 @@ static bool protect_or_check_icv(OPTIONAL uta_ctx* ctx, const char* file, const 
 
         char icv_hex[ICV_HEX_LEN + 1];
         bool found =
-            fsize >= ICV_LINE_LEN and strncmp((char*)(buf + fsize - ICV_LINE_LEN), ICV_TAG, strlen(ICV_TAG)) is_eq 0;
+            (size_t)fsize >= ICV_LINE_LEN and strncmp((char*)(buf + fsize - ICV_LINE_LEN), ICV_TAG, strlen(ICV_TAG)) is_eq 0;
 
         if(protect)
         {

--- a/src/util/log.c
+++ b/src/util/log.c
@@ -1,13 +1,13 @@
-/** 
+/**
 * @file log.c
-* 
+*
 * @brief Logging facility which, by default, outputs to syslog and console
 *
 * @copyright Copyright (c) Siemens Mobility GmbH, 2021
 *
 * @author David von Oheimb <david.von.oheimb@siemens.com>
 *
-* This work is licensed under the terms of the Apache Software License 
+* This work is licensed under the terms of the Apache Software License
 * 2.0. See the COPYING file in the top-level directory.
 *
 * SPDX-License-Identifier: Apache-2.0
@@ -22,8 +22,10 @@
 
 #include <assert.h>
 
-// use the GNU-specific `strerror_r`
-// https://man7.org/linux/man-pages/man3/strerror.3.html : SYNOPSIS
+/*
+ * use the GNU-specific `strerror_r`
+ * https://man7.org/linux/man-pages/man3/strerror.3.html : SYNOPSIS
+ */
 #define _GNU_SOURCE
 
 static LOG_cb_t LOG_fn = 0; /*!< this variable is shared between threads */


### PR DESCRIPTION
This is ~not yet~ meanwhile complete.
We meanwhile also added other related fixes to `Makefile_v1` and `CMakeLists.txt`
and added a couple of comments to `config_update.c`.