### PR TITLE
CMake: fix use of `secutils_static_config.h`, improve `clean_all` and `uninstall` targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,8 +186,11 @@ set_property(
 if(NOT TARGET clean_all)
   add_custom_target(clean_all
     COMMAND ${CMAKE_BUILD_TOOL} clean
-    # cowardly not doing rm -r ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}
     COMMAND find . -name "*.o" -o -regex "./libsecutils-.*" | xargs rm
+    COMMAND find . -type d -name "build" | xargs -r rm -r
+    # cowardly not doing rm -r ${CMAKE_BINARY_DIR}
+
+    COMMAND rm CMakeCache.txt
     # after the following, cannot call this target again:
     COMMAND find . ( -name "*.cmake" -o -name Makefile )
             -not -path ./src/libsecutils/security-utilities_libraryConfig.cmake
@@ -195,7 +198,11 @@ if(NOT TARGET clean_all)
             -not -path ./coverage/Makefile
             | xargs rm
     COMMAND find . -name CMakeFiles | xargs rm -r
-    COMMAND rm CMakeCache.txt
+    COMMAND find . -type d -empty      | xargs -r rmdir
+    COMMAND find . -type d -empty      | xargs -r rmdir
+    COMMAND find . -type d -empty      | xargs -r rmdir
+    COMMAND find . -type d -empty      | xargs -r rmdir
+    COMMAND find . -type d -empty      | xargs -r rmdir
     VERBATIM
   )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,6 @@ add_subdirectory(src)
 #else()
 #  set(CMAKE_INSTALL_PREFIX "tmp")
 #endif()
-#set(CMAKE_INSTALL_DOCDIR "${CMAKE_INSTALL_PREFIX}/share/doc")
 include(GNUInstallDirs) # any CMAKE_INSTALL_PREFIX must be set before
 
 # https://stackoverflow.com/questions/73248130/how-to-avoid-the-removal-of-the-rpath-during-cmake-install-step
@@ -152,8 +151,14 @@ if(NOT TARGET uninstall)
   add_custom_target(uninstall
     COMMAND xargs -I% rm -vf \${DESTDIR}% <install_manifest.txt
     COMMAND rm -vfr "\${DESTDIR}${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}/secutils"
-    COMMAND rm -vfr "\${DESTDIR}${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DOCDIR}"
+    COMMAND find . -path "./\${DESTDIR}${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}" -empty | xargs -r rmdir
     COMMAND rm -vfr "\${DESTDIR}${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+    COMMAND find . -path "./\${DESTDIR}${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}" -empty | xargs -r rmdir
+    COMMAND find . -path "./\${DESTDIR}${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/cmake" -empty | xargs -r rmdir
+    COMMAND find . -path "./\${DESTDIR}${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" -empty | xargs -r rmdir
+    COMMAND rm -vfr "\${DESTDIR}${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DOCDIR}"
+    COMMAND find . -path "./\${DESTDIR}${CMAKE_INSTALL_PREFIX}/share/doc" -empty | xargs -r rmdir
+    COMMAND find . -path "./\${DESTDIR}${CMAKE_INSTALL_PREFIX}/share" -empty | xargs -r rmdir
   )
 endif()
 

--- a/src/libsecutils/CMakeLists.txt
+++ b/src/libsecutils/CMakeLists.txt
@@ -72,5 +72,5 @@ install(DIRECTORY include/
     FILES_MATCHING
         PATTERN "*.h"
         PATTERN CMakeFiles EXCLUDE
-        PATTERN secutils_static_config.h EXCLUDE
+        # PATTERN secutils_static_config.h EXCLUDE # must not be excluded
 )

--- a/src/libsecutils/include/secutils/CMakeLists.txt
+++ b/src/libsecutils/include/secutils/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(security-utilities_library PRIVATE
 )
 
 target_include_directories(security-utilities_library PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}> # make sure that secutils_static_config.h is taken from the build dir
     $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
     $<INSTALL_INTERFACE:include>
 )

--- a/src/libsecutils/include/secutils/basic.h
+++ b/src/libsecutils/include/secutils/basic.h
@@ -16,7 +16,7 @@
 #ifndef SECUTILS_BASIC_H_
 #define SECUTILS_BASIC_H_
 
-#include "secutils_static_config.h"
+#include <secutils_static_config.h>
 
 /* this type is part of the genCMPClient API */
 #ifndef __cplusplus

--- a/src/libsecutils/include/secutils/util/CMakeLists.txt
+++ b/src/libsecutils/include/secutils/util/CMakeLists.txt
@@ -3,7 +3,3 @@ target_sources(security-utilities_library PRIVATE
     log.h
     util.h
 )
-
-target_include_directories(security-utilities_library PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
-)

--- a/src/util/Makefile_v1
+++ b/src/util/Makefile_v1
@@ -46,7 +46,7 @@ $(OUT_DIR_BIN): icvutil$(OBJ)
 	$(CC) $(LDFLAGS) icvutil$(OBJ) -o $(OUT_DIR_BIN) -L$(OUT_REVERSE_DIR) -lsecutils -lssl -lcrypto
 
 icvutil$(OBJ): icvutil.c
-	$(CC) $(CFLAGS) -I../include -c icvutil.c
+	$(CC) $(CFLAGS) -I../libsecutils/include/secutils -c icvutil.c
 
 run: build
 	LD_LIBRARY_PATH=../ $(OUT_DIR_BIN) || true


### PR DESCRIPTION
* make sure `secutils_static_config.h` is taken from build dir
* make sure that `secutils_static_config.h` gets installed
* remove needless addition of include path `src/libsecutils/include/secutils/util`
* `CMakeLists.txt`: extend `clean_al` target to remove `build` and empty directories
* `CMakeLists.txt`: improve `uninstall` target to remove empty directories