### PR TITLE
Fix TLS hostname handling etc.

### DIFF
--- a/src/libsecutils/include/secutils/connections/conn.h
+++ b/src/libsecutils/include/secutils/connections/conn.h
@@ -24,6 +24,7 @@ static const char* const CONN_https_prefix = "https://";
 
 #define CONN_IS_HTTP( uri) ((uri) != NULL && HAS_PREFIX(uri, OSSL_HTTP_PREFIX ))
 #define CONN_IS_HTTPS(uri) ((uri) != NULL && HAS_PREFIX(uri, OSSL_HTTPS_PREFIX))
+#define CONN_IS_IP_ADDR(host) ((host) != NULL && ((*(host) >= '0' && *(host) <= '9') || *(host) == '['))
 
 /*!*****************************************************************************
  * @brief parse hostname or URI of the form "[http[s]://][<userinfo>@]<host>[:<port>][/<path>]"

--- a/src/libsecutils/include/secutils/connections/conn.h
+++ b/src/libsecutils/include/secutils/connections/conn.h
@@ -26,22 +26,26 @@ static const char* const CONN_https_prefix = "https://";
 #define CONN_IS_HTTPS(uri) ((uri) != NULL && HAS_PREFIX(uri, OSSL_HTTPS_PREFIX))
 
 /*!*****************************************************************************
- * @brief parse URI of the form "[http[s]://]host[:port][/path]"
+ * @brief parse hostname or URI of the form "[http[s]://][<userinfo>@]<host>[:<port>][/<path>]"
+ * @note an IPv6 address must be enclosed in '[' and ']'.
  * @param p_uri pointer to variable holding the URI to be parsed.
- * The variable is advanced past any leading "http[s]://" and any given port and/or path strings are chopped.
+ * The variable is advanced past any leading "http[s]://" and "<userinfo>@" parts to the host name/address;
+ * anything following it (i.e., <port> and/or <path> URI components) are chopped in the input string buffer.
  * @param default_port specifies the default port to return:
  * may give an actual default port number or 0, which is replaced by 443 for https else by 80
  * @param p_path if this pointer is not null it will be used to assign on success
- * the pointer to any path component included in the input string, or null if not included.
+ * the pointer to any <path> component (including and query and fragment parts)
+ * included in the input string, or null if not included.
  * @param desc description of the server to connect to, for use in diagnostic messages, or null
  * @return valid port number from input string or default, or <= 0 on error
  ******************************************************************************/
 int CONN_parse_uri(char** p_uri, int default_port, const char** p_path, char* desc);
 
 /*!*****************************************************************************
- * @brief copy host name or IP address from URI of the form "[http[s]://]host[:port][/path]"
+ * @brief copy host name or IP address from URI of the form "[http[s]://][userinfo@]<host>[:<port>][/<path>]"
  *
- * @param uri (optional) containing host name or IP address
+ * @param uri (optional) containing host name or IP address.
+ * @note an IPv6 address must be enclosed in '[' and ']'.
  * @return pointer to a copy of the host specifier or null, null also on error
  ******************************************************************************/
 char* CONN_get_host(OPTIONAL const char* uri);

--- a/src/libsecutils/include/secutils/connections/conn.h
+++ b/src/libsecutils/include/secutils/connections/conn.h
@@ -22,6 +22,9 @@ static const char* const CONN_scheme_postfix = "://";
 static const char* const CONN_http_prefix = "http://";
 static const char* const CONN_https_prefix = "https://";
 
+#define CONN_IS_HTTP( uri) ((uri) != NULL && HAS_PREFIX(uri, OSSL_HTTP_PREFIX ))
+#define CONN_IS_HTTPS(uri) ((uri) != NULL && HAS_PREFIX(uri, OSSL_HTTPS_PREFIX))
+
 /*!*****************************************************************************
  * @brief parse URI of the form "[http[s]://]host[:port][/path]"
  * @param p_uri pointer to variable holding the URI to be parsed.

--- a/src/libsecutils/include/secutils/connections/tls.h
+++ b/src/libsecutils/include/secutils/connections/tls.h
@@ -92,11 +92,17 @@ void TLS_CTX_free(OPTIONAL SSL_CTX* ctx);
  *
  * @param ctx SSL/TLS context, typically obtained using TLS_CTX_new()
  * @param host the host name or IP address, which may be given as a URL, of the server to connect to
- * @note host name checking is enabled for the given host name or IP address
  * @param port (optional) the port number, given as string, to connect to
+ * @note an IPv6 address must be enclosed in '[' and ']'.
  * @note The host parameter may contain a ':' followed by a port specification.
  * In this case the port parameter must be null or contain the same string.
  * @param timeout number of seconds the HTTP transaction may take, or 0 for infinite
+ * @note the function performs Server Name Indication (SNI) according to RFC 3546 section 3.1.
+ * If the ctx parameter contains a trust store in which a host name has been set
+ * for host name validation (e.g., using STORE_set1_host_ip()), the function uses this name for SNI.
+ * Otherwise, it uses the host parameter given here for SNI (unless it is an IP address)
+ * and sets host name validation if a trust store is contained in the ctx
+ * and no IP address nor email address validation has been set there, neither.
  * @return pointer to a new SSL/TLS structure, or null on error
  *******************************************************************************/
 SSL* TLS_connect(SSL_CTX* ctx, const char* host, OPTIONAL const char* port, int timeout);

--- a/src/libsecutils/include/secutils/credentials/cert.h
+++ b/src/libsecutils/include/secutils/credentials/cert.h
@@ -104,7 +104,7 @@ void CERTS_free(OPTIONAL STACK_OF(X509) *certs);
  *
  * @param dn string to be parsed, format "/type0=value0/type1=value1/type2=..." where characters may be escaped by '\'.
  * The NULL-DN may be given as "/" or "".
- * @param chtype type of the string, e.g., MBSTRING_ASC, as defined in openssl/asn1.h
+ * @param chtype type of the string, e.g., MBSTRING_UTF8, as defined in openssl/asn1.h
  * @param multirdn flag whether to allow multi-valued RDNs
  * @return ASN.1 representation of the DN, or null on error
  *******************************************************************************/

--- a/src/libsecutils/include/secutils/credentials/key.h
+++ b/src/libsecutils/include/secutils/credentials/key.h
@@ -27,6 +27,7 @@
  * @note The RSA key length may be 1024, 2048, or 4096 and the available ECC curves can be shown with the command
  *openssl ecparam -list_curves.
  * @note This function cannot be used for generating keys managed by a crypto engine.
+ * @note Since OpenSSL 3.0, this may depend on the availability of a suitable provider.
  * @return the new key on success and null otherwise.
  *******************************************************************************/
 /* this function is part of the genCMPClient API */

--- a/src/libsecutils/include/secutils/credentials/store.h
+++ b/src/libsecutils/include/secutils/credentials/store.h
@@ -24,8 +24,9 @@
 # include "../certstatus/certstatus.h"
 
 /*!*****************************************************************************
- * @brief enable TLS host verification and define the expected server host name and/or IP address
- * @note it is crucial for TLS clients to verify the identity of the host to connect to
+ * @brief disable host name/address verification if the name and ip parameters are null, otherwise
+ enable TLS host verification and define the expected server host name and/or IP address
+ * @note it is crucial for TLS clients to verify the identity of the host to connect with
  *
  * @param truststore the trust store (typically returned from TLS_CTX_new()) where to set the host verification options
  * @param name the host DNS name to be expected, which may be given as a URL, or null
@@ -35,7 +36,7 @@
  * @return true on success, else false
  *******************************************************************************/
 /* this function is used by the genCMPClient API implementation */
-bool STORE_set1_host_ip(X509_STORE* truststore, const char* name, const char* ip);
+bool STORE_set1_host_ip(X509_STORE* truststore, OPTIONAL const char* name, OPTIONAL const char* ip);
 
 /*!*****************************************************************************
  * @brief add CRLs to trust store and enable CRL-based status checks for end-entity certificates

--- a/src/libsecutils/include/secutils/credentials/store.h
+++ b/src/libsecutils/include/secutils/credentials/store.h
@@ -252,6 +252,7 @@ bool STORE_EX_check_index(void);
  * @param store the affected certificate store
  * @param host the host name to set, or null to clear it
  * @return true on success, false on failure
+ * @note since OpenSSL 3.0, this is no more needed due to X509_VERIFY_PARAM_get0_host() being available
  */
 bool STORE_set1_host(X509_STORE* store, OPTIONAL const char* host);
 
@@ -259,7 +260,7 @@ bool STORE_set1_host(X509_STORE* store, OPTIONAL const char* host);
  * @brief get expected host name for cert verification diagnostics
  *
  * @param store the certificate store to read from
- * @return the host name that has been set, or null if unset or on failure
+ * @return the first host name that has been set, or null if unset or on failure
  */
 const char* STORE_get0_host(X509_STORE* store);
 

--- a/src/libsecutils/src/credentials/key.c
+++ b/src/libsecutils/src/credentials/key.c
@@ -198,7 +198,7 @@ EVP_PKEY* KEY_new(const char* spec)
         }
 
 #if OPENSSL_VERSION_NUMBER >= OPENSSL_V_3_0_0
-        pkey = EVP_RSA_gen(nbits);
+        pkey = EVP_RSA_gen(nbits); // This may depend on the availability of a suitable OpenSSL provider.
         if (pkey == NULL) {
             LOG(FL_ERR, "cannot generate RSA key with length %d", nbits);
             goto err;
@@ -263,7 +263,7 @@ EVP_PKEY* KEY_new(const char* spec)
         }
 
 #if OPENSSL_VERSION_NUMBER >= OPENSSL_V_3_0_0
-        pkey = EVP_EC_gen(OSSL_EC_curve_nid2name(nid));
+        pkey = EVP_EC_gen(OSSL_EC_curve_nid2name(nid)); // This may depend on the availability of a suitable OpenSSL provider.
         if (pkey == NULL) {
             LOG(FL_ERR, "cannot generate EC key with curve name %.40s", spec);
             goto err;

--- a/src/libsecutils/src/credentials/store.c
+++ b/src/libsecutils/src/credentials/store.c
@@ -467,7 +467,7 @@ err:
 }
 
 
-bool STORE_set1_host_ip(X509_STORE* ts, const char* name, const char* ip)
+bool STORE_set1_host_ip(X509_STORE* ts, OPTIONAL const char* name, OPTIONAL const char* ip)
 {
     if(ts is_eq 0)
     {
@@ -482,7 +482,7 @@ bool STORE_set1_host_ip(X509_STORE* ts, const char* name, const char* ip)
        0 is_eq X509_VERIFY_PARAM_set1_ip(ts_vpm, 0, 0) or
        0 is_eq X509_VERIFY_PARAM_set1_email(ts_vpm, 0, 0))
     {
-        LOG_err("Could not clear host name and IP address from store");
+        LOG_err("Could not clear host names and IP and email addresses from store");
         return false;
     }
 


### PR DESCRIPTION
* `TLS_connect()`: fix setting the SNI extension and the host name validation
* `CONN_parse_uri(),CONN_get_host()`: make sure to skip any given `<userinfo>@` URL component; extend doc
* `STORE_set1_host{,_ip}(),STORE_get0_host()`: update possible since OpenSSL 3.0: use `X509_VERIFY_PARAM_get0_host()` and add respective comments
* `STORE_set1_host_ip()`: add missing OPTIONAL parameter hints, fix doc and diagnostic output
* `key.{c,h}`: add hint that key generation can depend on OpenSSL providers
* `conn.h`: add `CONN_IS_HTTP()` and `CONN_IS_HTTPS()` macros