### PR TITLE
`CONN_is_IP_address()`: prevent crash freeing uninitialized 'res' on unsuccessful `getaddrinfo()` call

### DIFF
--- a/src/libsecutils/src/connections/conn.c
+++ b/src/libsecutils/src/connections/conn.c
@@ -35,7 +35,7 @@
 bool CONN_is_IP_address(OPTIONAL const char *host)
 {
     size_t len;
-    struct addrinfo hints, *res;
+    struct addrinfo hints, *res = NULL;
     int ret;
 
     if (host == NULL)
@@ -50,7 +50,7 @@ bool CONN_is_IP_address(OPTIONAL const char *host)
     memset(&hints, 0, sizeof(hints));
     hints.ai_flags = AI_NUMERICHOST;
     ret = getaddrinfo(host, NULL, &hints, &res);
-    if (res != NULL)
+    if (ret == 0)
         freeaddrinfo(res);
     return ret == 0;
 }


### PR DESCRIPTION
This will prevent a crash reported by a genCMPClient user:

<img width="1885" height="842" alt="crash_CONN_is_IP_address" src="https://github.com/user-attachments/assets/1d832833-6d18-4a06-9f39-1a019e004fbb" />
