### PR TITLE
add support for ML-DSA-* etc., various small fixes; C23 and OpenSSL 4.0 compat

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+libsecutils (2.3) stable; urgency=medium
+
+    * TODO: complete this and update date below
+    * extend KEY_new() to support ML-DSA-* and potentially further PQC algorithms
+    * add KEY_new_ex() for improved provider support
+    * improve STORE_set1_host_ip() behavior on equal 'name' and 'ip' argument
+    * CREDENTIALS_print_cert_verify_cb(): fix output of expected IP address on mismatch
+    * improve CONN_IS_HTTP(S) and use it to replace respective occurrences of strncasecmp()
+    * credentials.c: fix potential crash of find_update_cb() on NULL tag/description strings
+    * crl_mgmt.c,cdp_util.{c,h}: fix constness for OpenSSL 4.0 compatibility
+    * basic.h: fix compatibility with C23, which provides 'true' and 'false' as keywords
+
+ -- David von Oheimb <David.von.Oheimb@siemens.com>  Fri, 15 May 2026 16:12:48 +0200
+
 libsecutils (2.2) stable; urgency=medium
 
   * add UTIL_cmp_timeframe() and CRL_check() for support of upcoming OpenSSL 4.0

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,16 +1,29 @@
 libsecutils (2.3) stable; urgency=medium
 
-    * TODO: complete this and update date below
-    * extend KEY_new() to support ML-DSA-* and potentially further PQC algorithms
+    * TODO: complete this and update date below 
+    * extend KEY_new() to support ML-DSA-* and potentially further PQC algs
     * add KEY_new_ex() for improved provider support
     * improve STORE_set1_host_ip() behavior on equal 'name' and 'ip' argument
-    * CREDENTIALS_print_cert_verify_cb(): fix output of expected IP address on mismatch
-    * improve CONN_IS_HTTP(S) and use it to replace respective occurrences of strncasecmp()
-    * credentials.c: fix potential crash of find_update_cb() on NULL tag/description strings
+    * CREDENTIALS_print_cert_verify_cb(): fix print expected IP addr on mismatch
+    * improve CONN_IS_HTTP(S) and use it to replace occurrences of strncasecmp()
+    * credentials.c: fix potential crash of find_update_cb() on NULL tag strings
     * crl_mgmt.c,cdp_util.{c,h}: fix constness for OpenSSL 4.0 compatibility
-    * basic.h: fix compatibility with C23, which provides 'true' and 'false' as keywords
+    * basic.h: fix compat with C23 which provides 'true' and 'false' as keywords
+    * build.yml: add 'lintian --fail-on error,warning *deb' after 'make deb'
+    * CMakeLists.txt: improve Windows support, partly clean up gcc warning opts
+    * CMakeLists.txt,debian/etc. major improvements of Debian packaging
+    * CMakeLists.txt,debian/: add library major version to name (libsecutils2)
+    * CMakeLists.txt,debian/control: shorten CPACK_PACKAGE_DESCRIPTION_SUMMARY
+    * CMakeLists.txt: Ensure installed directories get standard 0755 permissions
+    * CMakeLists.txt,build.yml: improve uninstall and CI checks
+    * CMakeLists.txt: simplify (sub-)directory structure of doc/
+    * add icvutil.1 man page and its Debian installation
+    * add placeholder 'icvutil' script in case binary is not available
+    * chore: add pkgconfig file
+    * Makefile_v1: make fallback determination of OPENSSL_LIB more reliable
+    * Makefile_v1: improve dir pattern for auto-determining OPENSSL_LIB on Linux
 
- -- David von Oheimb <David.von.Oheimb@siemens.com>  Fri, 15 May 2026 16:12:48 +0200
+ -- David von Oheimb <David.von.Oheimb@siemens.com>  Tue, 23 Jun 2026 17:24:50 +0200
 
 libsecutils (2.2) stable; urgency=medium
 

--- a/src/libsecutils/include/secutils/certstatus/cdp_util.h
+++ b/src/libsecutils/include/secutils/certstatus/cdp_util.h
@@ -43,7 +43,7 @@ typedef int CDP_REASON_FLAGS;
 
 /* Copy a one-line representation of the X509_NAME into the buffer */
 bool CDP_get_x509_name(
-    X509_NAME       *name,
+    const X509_NAME *name,
     char            *name_utf8_buf,
     size_t          name_utf8_buf_len,
     unsigned long   flags

--- a/src/libsecutils/include/secutils/connections/conn.h
+++ b/src/libsecutils/include/secutils/connections/conn.h
@@ -16,14 +16,22 @@
 #ifndef SECUTILS_CONN_H_
 # define SECUTILS_CONN_H_
 
-# include "../basic.h"
+# include "../util/util.h"
 
+# if OPENSSL_VERSION_NUMBER < OPENSSL_V_3_0_0
+#  undef  OSSL_HTTP_PREFIX
+#  define OSSL_HTTP_PREFIX "http://"
+#  undef  OSSL_HTTPS_PREFIX
+#  define OSSL_HTTPS_PREFIX "https://"
+# else
+#  include <openssl/http.h>
+# endif
 static const char* const CONN_scheme_postfix = "://";
-static const char* const CONN_http_prefix = "http://";
-static const char* const CONN_https_prefix = "https://";
+static const char* const CONN_http_prefix = OSSL_HTTP_PREFIX;
+static const char* const CONN_https_prefix = OSSL_HTTPS_PREFIX;
 
-#define CONN_IS_HTTP( uri) ((uri) != NULL && HAS_PREFIX(uri, OSSL_HTTP_PREFIX ))
-#define CONN_IS_HTTPS(uri) ((uri) != NULL && HAS_PREFIX(uri, OSSL_HTTPS_PREFIX))
+#define CONN_IS_HTTP( uri) ((uri) != NULL && HAS_CASE_PREFIX(uri, OSSL_HTTP_PREFIX ))
+#define CONN_IS_HTTPS(uri) ((uri) != NULL && HAS_CASE_PREFIX(uri, OSSL_HTTPS_PREFIX))
 #define CONN_IS_IP_ADDR(host) CONN_is_IP_address(host)
 
 /*!*****************************************************************************
@@ -35,15 +43,15 @@ static const char* const CONN_https_prefix = "https://";
 bool CONN_is_IP_address(OPTIONAL const char *host);
 
 /*!*****************************************************************************
- * @brief parse hostname or URI of the form "[http[s]://][<userinfo>@]<host>[:<port>][/<path>]"
+ * @brief parse hostname or URI of the form "[http[s]://][<userinfo>@]<host>[:port][/<path>]"
  * @note an IPv6 address must be enclosed in '[' and ']'.
  * @param p_uri pointer to variable holding the URI to be parsed.
  * The variable is advanced past any leading "http[s]://" and "<userinfo>@" parts to the host name/address;
- * anything following it (i.e., <port> and/or <path> URI components) are chopped in the input string buffer.
+ * anything following it (i.e., port and/or path URI components) are chopped in the input string buffer.
  * @param default_port specifies the default port to return:
  * may give an actual default port number or 0, which is replaced by 443 for https else by 80
  * @param p_path if this pointer is not null it will be used to assign on success
- * the pointer to any <path> component (including and query and fragment parts)
+ * the pointer to any path component (including any query and fragment parts)
  * included in the input string, or null if not included.
  * @param desc description of the server to connect to, for use in diagnostic messages, or null
  * @return valid port number from input string or default, or <= 0 on error

--- a/src/libsecutils/include/secutils/credentials/credentials.h
+++ b/src/libsecutils/include/secutils/credentials/credentials.h
@@ -190,19 +190,20 @@ CREDENTIALS* CREDENTIALS_load_dv(OPTIONAL const char* certs, OPTIONAL const char
 
 
 /*!*****************************************************************************
- * @brief save asymmetric credentials (except key held in crypto engine) to the given file(s)
+ * @brief save asymmetric credentials (except key held in crypto engine or provider) to the given file(s)
  * @note If used, encryption indirectly also protects integrity&authenticity of file-based storage.
  *
  * @param creds pointer to the credential structure to save
  * @param certs name of file to store certificates, or null. Any previous contents are overwritten.
- * @param key name of file to store the private key unless the 'source' parameter
- *  refers to an engine (where this parameter may be null). Any previous file contents are overwritten.
+ * @param key name of file to store the private key unless
+ *   the 'source' parameter refers to an engine (where the 'key' parameter may be null).
  * @param source if this parameter is null or of the form "pass:PWD" then the key
  *   is stored to the given key. If present, PWD is taken as password to be
  *   used for key encryption. If the 'source' parameter is of the form "engine:<id>"
  *   the key is not stored because this does not apply for the engine interface.
  * @param desc (optional) is used if present for forming more descriptive error messages
  * @return true on success, else failure
+ * @note Any previous file contents are overwritten.
  * @note If the 'certs' and 'key' arguments are equal and the file name extension is ".p12" or ".pkcs12",
  * the certs and the key are written jointly to the same PKCS#12 file.
  * Otherwise they are written in PEM format, potentially jointly to the same file.

--- a/src/libsecutils/include/secutils/credentials/key.h
+++ b/src/libsecutils/include/secutils/credentials/key.h
@@ -19,20 +19,31 @@
 #include <openssl/evp.h>
 
 #include "../basic.h"
+#include "../util/util.h" /* for OSSL_LIB_CTX legacy workaround */
 
 /*!*****************************************************************************
  * @brief generate a new private key according to the given specification
  *
- * @param spec specification for the type of the new key, which may be of the form "EC:<curve>" or "RSA-<length>"
- * @note The RSA key length may be 1024, 2048, or 4096 and the available ECC curves can be shown with the command
- *openssl ecparam -list_curves.
+ * @param spec specification for the type of the new key.
+ * For ECC and RSA keys, this can be of the form "EC:<curve>", "RSA:<length>", "RSA-<length>" or "<length>".
+ * Everything else is considered an ECC curve name if the OpenSSL version is below 3.5,
+ * while for OpenSSL 3.5+, it is taken as an algorithm name, potentially including parameters, such as "ED25519" or "ML-DSA-<level>".
+ * For the full list of available algorithms see the output of openssl list -public-key-algorithms
+ * @param libctx for optional use with providers with OpenSSL 3.0+, otherwise must be null
+ * @param propq may give a provider query string with OpenSSL 3.0+, otherwise must be null
+ * @note The RSA key length may be 1024, 2048, 4096, or 8192 and the available ECC curves
+ * can be shown with the command `openssl ecparam -list_curves`.
  * @note This function cannot be used for generating keys managed by a crypto engine.
  * @note Since OpenSSL 3.0, this may depend on the availability of a suitable provider.
  * @return the new key on success and null otherwise.
  *******************************************************************************/
 /* this function is part of the genCMPClient API */
-EVP_PKEY* KEY_new(const char* spec);
+EVP_PKEY *KEY_new_ex(const char *spec, OPTIONAL OSSL_LIB_CTX *libctx, OPTIONAL const char *propq);
+#define SECUTILS_RSA_STR "RSA"
+#define SECUTILS_EC_STR "EC"
 
+/* this function is part of the genCMPClient API */
+EVP_PKEY *KEY_new(const char *spec); /* same as KEY_new_ex(spec, NULL, NULL) */
 
 /*!*****************************************************************************
  * @brief free an asymmetric (private) key

--- a/src/libsecutils/include/secutils/credentials/store.h
+++ b/src/libsecutils/include/secutils/credentials/store.h
@@ -31,7 +31,9 @@
  * @param truststore the trust store (typically returned from TLS_CTX_new()) where to set the host verification options
  * @param name the host DNS name to be expected, which may be given as a URL, or null
  * @param ip the host IP address to be expected, which may be given as a URL, or null
- * @note if both name and ip are non-null and equal, tries to interpret the string first as IP address then as domain name.
+ * @note if both name and ip are non-null and are non-equal strings, both expectations are set.
+ * @note if both name and ip are non-null and equal strings, the function uses CONN_IS_IP_ADDR()
+ * to determine whether to interpret the string as an IP address or as a domain name.
  * @note name and ip strings are copied, so do not need to be preserved after the call.
  * @return true on success, else false
  *******************************************************************************/

--- a/src/libsecutils/include/secutils/util/util.h
+++ b/src/libsecutils/include/secutils/util/util.h
@@ -48,6 +48,7 @@ static const int UTIL_max_name_len = 128;  /*!< max length of file name */
 # define OPENSSL_V_1_1_0 0x10100000L
 # define OPENSSL_V_1_1_1 0x10101000L
 # define OPENSSL_V_3_0_0 0x30000000L
+# define OPENSSL_V_3_5_0 0x30500000L
 # define OPENSSL_V_4_0_0 0x40000000L
 
 # ifndef OpenSSL_version_num
@@ -194,6 +195,7 @@ typedef u_int64_t uint64_t;
 # endif
 
 # if OPENSSL_VERSION_NUMBER < OPENSSL_V_3_0_0
+typedef void OSSL_LIB_CTX;
 STACK_OF(X509) *X509_STORE_get1_all_certs(X509_STORE *store);
 #  define X509_VERIFY_PARAM_get0_email(vpm) ((void)(vpm), NULL) /* dummy */
 #  define X509_VERIFY_PARAM_get1_ip_asc(vpm) ((void)(vpm), NULL) /* dummy */

--- a/src/libsecutils/include/secutils/util/util.h
+++ b/src/libsecutils/include/secutils/util/util.h
@@ -329,6 +329,14 @@ bool UTIL_get_random(void *buf, size_t len);
 #define HAS_CASE_PREFIX(s, p) (strncasecmp(s, p "", sizeof(p) - 1) == 0)
 /* As before, and if check succeeds, advance |str| past the prefix |pre| */
 #define CHECK_AND_SKIP_CASE_PREFIX(str, pre) (HAS_CASE_PREFIX(str, pre) ? ((str) += sizeof(pre) - 1, 1) : 0)
+/* Advance string pointer s, which must a modifiable lvalue, past scheme according to RFC 3986: ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ) */
+#define UTIL_SKIP_SCHEME(s)                                                        \
+    do {                                                                           \
+        if (isalpha(*(s)))                                                         \
+            while (*(s) != '\0' && (isalnum(*(s)) || strchr("+-.", *(s)) != NULL)) \
+                (s)++;                                                             \
+    } while (0)
+#define UTIL_SCHEME_SUFFIX "://"
 
 /*!
  * @brief The function copies the source string into the destination buffer

--- a/src/libsecutils/include/secutils/util/util.h
+++ b/src/libsecutils/include/secutils/util/util.h
@@ -321,8 +321,14 @@ void UTIL_cleanse_free(OPTIONAL char *str);
  */
 bool UTIL_get_random(void *buf, size_t len);
 
+/* Check if |pre|, which must be a string literal, is a prefix of |str| */
 #define HAS_PREFIX(str, pre) (strncmp(str, pre "", sizeof(pre) - 1) == 0)
+/* As before, and if check succeeds, advance |str| past the prefix |pre| */
 #define CHECK_AND_SKIP_PREFIX(str, pre) (HAS_PREFIX(str, pre) ? ((str) += sizeof(pre) - 1, 1) : 0)
+/* Check if the string literal |p| is a case-insensitive prefix of |s| */
+#define HAS_CASE_PREFIX(s, p) (strncasecmp(s, p "", sizeof(p) - 1) == 0)
+/* As before, and if check succeeds, advance |str| past the prefix |pre| */
+#define CHECK_AND_SKIP_CASE_PREFIX(str, pre) (HAS_CASE_PREFIX(str, pre) ? ((str) += sizeof(pre) - 1, 1) : 0)
 
 /*!
  * @brief The function copies the source string into the destination buffer

--- a/src/libsecutils/src/certstatus/cdp_util.c
+++ b/src/libsecutils/src/certstatus/cdp_util.c
@@ -1,13 +1,13 @@
-/** 
+/**
 * @file cdp_util.c
-* 
+*
 * @brief Utilities needed by and assisting the CDP functionality
 *
 * @copyright Copyright (c) Siemens Mobility GmbH, 2021
 *
 * @author David von Oheimb <david.von.oheimb@siemens.com>
 *
-* This work is licensed under the terms of the Apache Software License 
+* This work is licensed under the terms of the Apache Software License
 * 2.0. See the COPYING file in the top-level directory.
 *
 * SPDX-License-Identifier: Apache-2.0
@@ -15,6 +15,7 @@
 
 #include <certstatus/cdp_util.h>
 #include <certstatus/certstatus.h>
+#include <connections/conn.h> /* for CONN_IS_HTTP(S) */
 
 bool CDP_get_x509_name(
     const X509_NAME *name,
@@ -87,9 +88,8 @@ const char *CDP_get_uri_from_general_names(
         if(gtype == GEN_URI && ASN1_STRING_length(uri) > 7)
         {
             /* uri is of type ASN1_STRING */
-            const char* asn1_uri = (char*)ASN1_STRING_get0_data(uri);
-            if(strncasecmp(asn1_uri, "http://", 7) == 0
-               || strncasecmp(asn1_uri, "https://", 8) == 0)
+            const char *asn1_uri = (const char *)ASN1_STRING_get0_data(uri);
+            if (CONN_IS_HTTP(asn1_uri) || CONN_IS_HTTPS(asn1_uri))
             {
                 return asn1_uri;
             }

--- a/src/libsecutils/src/certstatus/cdp_util.c
+++ b/src/libsecutils/src/certstatus/cdp_util.c
@@ -17,7 +17,7 @@
 #include <certstatus/certstatus.h>
 
 bool CDP_get_x509_name(
-    X509_NAME       *name,
+    const X509_NAME *name,
     char            *name_utf8_buf,
     size_t          name_utf8_buf_len,
     unsigned long   flags)

--- a/src/libsecutils/src/certstatus/crl_mgmt.c
+++ b/src/libsecutils/src/certstatus/crl_mgmt.c
@@ -143,8 +143,8 @@ static X509_CRL *get_crl_from_cache(const char * cachefile)
 
         int nextPublishIdx = X509_CRL_get_ext_by_NID(crl, NID_crl_next_publish, 0);
         if (nextPublishIdx >= 0) {
-            X509_EXTENSION *ex = X509_CRL_get_ext(crl, nextPublishIdx);
-            ASN1_OCTET_STRING *data = X509_EXTENSION_get_data(ex);
+            const X509_EXTENSION *ex = X509_CRL_get_ext(crl, nextPublishIdx);
+            const ASN1_OCTET_STRING *data = X509_EXTENSION_get_data(ex);
             if (B_ASN1_T61STRING == ASN1_STRING_type(data)) {
 #if OPENSSL_VERSION_NUMBER < 0x10101000L
                 LOG(FL_ERR, "CRL nextPublish extension is present, but ASN1_TIME_set_string_X509 is not supported for OpenSSL version <1.1, sorry");

--- a/src/libsecutils/src/certstatus/crl_mgmt.c
+++ b/src/libsecutils/src/certstatus/crl_mgmt.c
@@ -143,7 +143,10 @@ static X509_CRL *get_crl_from_cache(const char * cachefile)
 
         int nextPublishIdx = X509_CRL_get_ext_by_NID(crl, NID_crl_next_publish, 0);
         if (nextPublishIdx >= 0) {
-            const X509_EXTENSION *ex = X509_CRL_get_ext(crl, nextPublishIdx);
+#if OPENSSL_VERSION_NUMBER >= OPENSSL_V_4_0_0
+            const
+#endif
+            X509_EXTENSION *ex = X509_CRL_get_ext(crl, nextPublishIdx);
             const ASN1_OCTET_STRING *data = X509_EXTENSION_get_data(ex);
             if (B_ASN1_T61STRING == ASN1_STRING_type(data)) {
 #if OPENSSL_VERSION_NUMBER < 0x10101000L

--- a/src/libsecutils/src/certstatus/crls.c
+++ b/src/libsecutils/src/certstatus/crls.c
@@ -300,8 +300,7 @@ static const char* get_dp_url(DIST_POINT* dp)
         if(gtype is_eq GEN_URI and ASN1_STRING_length(uri) > 6)
         {
             char* uptr = (char*)ASN1_STRING_get0_data(uri);
-            if(strncasecmp(uptr, CONN_http_prefix, strlen(CONN_http_prefix)) is_eq 0
-               or strncasecmp(uptr, "file:", 5) is_eq 0)
+            if (CONN_IS_HTTP(uptr) || HAS_CASE_PREFIX(uptr, "file:"))
             {
                 return uptr;
             }

--- a/src/libsecutils/src/connections/conn.c
+++ b/src/libsecutils/src/connections/conn.c
@@ -21,38 +21,24 @@
 # include <openssl/ssl.h>
 #endif
 
-/* for getaddrinfo() and freeaddrinfo() */
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <netdb.h>
-#ifdef _WIN32
-# include <winsock2.h>
-# include <ws2tcpip.h>
-#endif
-
 #include <operators.h>
 
 bool CONN_is_IP_address(OPTIONAL const char *host)
 {
-    size_t len;
-    struct addrinfo hints, *res = NULL;
-    int ret;
-
     if (host == NULL)
         return false;
 
     /* presume IPv6 address literal if host has the form "[<other-chars>]" */
-    len = strlen(host);
+    size_t len = strlen(host);
     if (len > 2 && *host == '[' && strchr(host + 1, '[') == NULL
             && strchr(host + 1, ']') == host + len - 1)
         return true;
 
-    memset(&hints, 0, sizeof(hints));
-    hints.ai_flags = AI_NUMERICHOST;
-    ret = getaddrinfo(host, NULL, &hints, &res);
-    if (ret == 0)
-        freeaddrinfo(res);
-    return ret == 0;
+    ERR_set_mark();
+    ASN1_OCTET_STRING *str = a2i_IPADDRESS(host);
+    ERR_pop_to_mark();
+    ASN1_OCTET_STRING_free(str);
+    return str != NULL;
 }
 
 static const char* skip_scheme(const char* str)

--- a/src/libsecutils/src/connections/conn.c
+++ b/src/libsecutils/src/connections/conn.c
@@ -41,13 +41,12 @@ bool CONN_is_IP_address(OPTIONAL const char *host)
     return str != NULL;
 }
 
-static const char* skip_scheme(const char* str)
+static const char *skip_scheme(const char *str)
 {
-    const char *scheme_end = strstr(str, CONN_scheme_postfix);
-    if(0 not_eq scheme_end)
-    {
-        str = scheme_end + strlen(CONN_scheme_postfix);
-    }
+    const char *scheme_end = str;
+    UTIL_SKIP_SCHEME(scheme_end);
+    if (scheme_end != str && CHECK_AND_SKIP_PREFIX(scheme_end, UTIL_SCHEME_SUFFIX))
+        str = scheme_end;
     return str;
 }
 

--- a/src/libsecutils/src/connections/conn.c
+++ b/src/libsecutils/src/connections/conn.c
@@ -1,13 +1,13 @@
-/** 
+/**
 * @file conn.c
-* 
+*
 * @brief Communication via OpenSSL BIO
 *
 * @copyright Copyright (c) Siemens Mobility GmbH, 2021
 *
 * @author David von Oheimb <david.von.oheimb@siemens.com>
 *
-* This work is licensed under the terms of the Apache Software License 
+* This work is licensed under the terms of the Apache Software License
 * 2.0. See the COPYING file in the top-level directory.
 *
 * SPDX-License-Identifier: Apache-2.0
@@ -95,7 +95,7 @@ int CONN_parse_uri(char** p_uri, int default_port, const char** p_path, char* de
         desc = "";
     }
 
-    if(strncasecmp(*p_uri, CONN_https_prefix, strlen(CONN_https_prefix)) is_eq 0)
+    if (CONN_IS_HTTPS(*p_uri))
     {
         *p_uri += strlen(CONN_https_prefix);
         if(0 is_eq default_port)
@@ -283,7 +283,7 @@ BIO* CONN_new(const char* host, const char* port)
         return 0;
     }
     if(port not_eq 0 /* else host_port is not null and has been used */
-       and not BIO_set_conn_port(bio, port)) 
+       and not BIO_set_conn_port(bio, port))
     {
         LOG(FL_ERR, "cannot set port for connect BIO");
         BIO_free(bio);

--- a/src/libsecutils/src/credentials/credentials.c
+++ b/src/libsecutils/src/credentials/credentials.c
@@ -20,6 +20,7 @@
 #include <openssl/engine.h>
 
 #include <credentials/cert.h>
+#include <credentials/key.h>
 #include <credentials/store.h>
 #include <credentials/verify.h>
 #include <storage/files.h>
@@ -309,9 +310,11 @@ static struct update_cb_node update_cb_head /*!< this struct variable is shared 
 
 /* find node just before the one related to the given tag assuming mutex */
 /*! @todo does not work if callers use different secutils instances */
-static update_cb_node* find_update_cb(const char* tag)
+static update_cb_node* find_update_cb(OPTIONAL const char* tag)
 {
     update_cb_node* prev = &update_cb_head;
+    if (tag == NULL)
+        tag = "";
     while (prev->next != NULL && strcmp(prev->next->tag == NULL ? "" : prev->next->tag, tag) != 0)
         prev = prev->next;
     return prev;
@@ -322,32 +325,34 @@ bool CREDENTIALS_save(const CREDENTIALS* creds, OPTIONAL const char* certs, OPTI
                       OPTIONAL const char* source, OPTIONAL const char* desc)
 {
     EVP_PKEY* pkey = 0;
+    update_cb_node *prev = NULL;
 
     if(creds is_eq 0 or (certs is_eq 0 and key is_eq 0))
     {
         LOG_err("null pointer argument");
         return false;
     }
-    if(source is_eq 0 or strncmp(source, sec_ENGINE_STR, strlen(sec_ENGINE_STR)) not_eq 0)
-    {
-        pkey = creds->pkey;
-    } else {
+    if (source != NULL && strncmp(source, sec_ENGINE_STR, strlen(sec_ENGINE_STR)) == 0) {
         /* source refers to engine, so cannot save private key */
-        source = 0;
+        key = NULL;
+        source = NULL;
+    } else {
+        pkey = creds->pkey;
     }
 
-    file_format_t format = key not_eq 0 and strcmp(key, certs) is_eq 0 ? FILES_get_format(key) : FORMAT_PEM;
+    file_format_t format = key != NULL && certs != NULL && strcmp(key, certs) == 0 ? FILES_get_format(key) : FORMAT_PEM;
     bool res = FILES_store_credentials(pkey, creds->cert, creds->chain, key, certs, format, source, desc);
     if(0 is_eq res)
     {
-        LOG(FL_ERR, "Could not save %s to %s and %s", desc not_eq 0 ? desc : "credentials", certs, key);
+        LOG(FL_ERR, "Could not save %s to %s and %s", desc != NULL ? desc : "credentials",
+            certs != NULL ? certs : "(none)", key != NULL ? key : "(none)");
         return false;
     }
 
     if (desc == NULL)
         desc = "";
     /*! @todo make thread safe, e.g., by using some mutex on update_cb_head */
-    update_cb_node* prev = find_update_cb(desc /* tag */);
+    prev = find_update_cb(desc /* tag */);
     if(prev->next not_eq 0)
     {
         (*prev->next->fn)(desc /* tag */);

--- a/src/libsecutils/src/credentials/credentials.c
+++ b/src/libsecutils/src/credentials/credentials.c
@@ -312,10 +312,8 @@ static struct update_cb_node update_cb_head /*!< this struct variable is shared 
 static update_cb_node* find_update_cb(const char* tag)
 {
     update_cb_node* prev = &update_cb_head;
-    while(prev->next not_eq 0 and strcmp(prev->next->tag, tag) not_eq 0)
-    {
+    while (prev->next != NULL && strcmp(prev->next->tag == NULL ? "" : prev->next->tag, tag) != 0)
         prev = prev->next;
-    }
     return prev;
 }
 
@@ -346,6 +344,8 @@ bool CREDENTIALS_save(const CREDENTIALS* creds, OPTIONAL const char* certs, OPTI
         return false;
     }
 
+    if (desc == NULL)
+        desc = "";
     /*! @todo make thread safe, e.g., by using some mutex on update_cb_head */
     update_cb_node* prev = find_update_cb(desc /* tag */);
     if(prev->next not_eq 0)

--- a/src/libsecutils/src/credentials/key.c
+++ b/src/libsecutils/src/credentials/key.c
@@ -16,63 +16,114 @@
 #include <openssl/bn.h>
 #include <openssl/ec.h>
 #include <openssl/rsa.h>
-
+#include <errno.h>
+#include <stdlib.h> /* for strtoul() */
+#include <ctype.h> /* for isspace() */
+#include <limits.h> /* for UINT_MAX */
 #include <credentials/key.h>
 #include <util/log.h>
 
 #include <operators.h>
 
-EVP_PKEY* KEY_new(const char* spec)
+
+EVP_PKEY *KEY_new(const char *spec)
+{
+    return KEY_new_ex(spec, NULL, NULL);
+}
+
+EVP_PKEY *KEY_new_ex(const char *spec, OPTIONAL OSSL_LIB_CTX *libctx, OPTIONAL const char *propq)
 {
     if(0 is_eq spec)
     {
         LOG(FL_ERR, "null pointer argument");
-        return 0;
+        return NULL;
     }
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < OPENSSL_V_3_0_0
+    if (libctx != NULL) {
+        LOG(FL_ERR, "libctx not supported by OpenSSL < 3.0");
+        return NULL;
+    }
+    if (propq != NULL) {
+        LOG(FL_ERR, "provider property query not supported by OpenSSL < 3.0");
+        return NULL;
+    }
+#endif
 
+    EVP_PKEY *pkey = NULL;
+    int type = EVP_PKEY_NONE;
+    const char *name = spec;
+    int nbits = 0, nid = 0;
+
+    if (CHECK_AND_SKIP_CASE_PREFIX(spec, SECUTILS_RSA_STR)) {
+        type = EVP_PKEY_RSA;
+        name = SECUTILS_RSA_STR;
+    } else if ('0' <= *spec && *spec <= '9') {
+        type = EVP_PKEY_RSA;
+        name = SECUTILS_RSA_STR;
+    } else if (CHECK_AND_SKIP_CASE_PREFIX(spec, SECUTILS_EC_STR)
+               && *spec != '\0' && strchr(" -_:", *spec) != NULL) {
+        type = EVP_PKEY_EC;
+        name = SECUTILS_EC_STR;
+    } else {
+        spec = name;
+
+        /* Backward compatibility: treat bare EC curve names as EC parameters. */
+         int curve_nid = OBJ_sn2nid(spec);
+         if (curve_nid == 0)
+             curve_nid = EC_curve_nist2nid(spec);
+         if (curve_nid != 0) {
+             type = EVP_PKEY_EC;
+             name = SECUTILS_EC_STR;
+         }
+#if OPENSSL_VERSION_NUMBER < OPENSSL_V_3_5_0
+         else {
+             /* For OpenSSL < 3.5, treat everything else as an EC curve name. */
+             type = EVP_PKEY_EC;
+             name = SECUTILS_EC_STR;
+         }
+#endif
+    }
+    if (type != EVP_PKEY_NONE && *spec != '\0' && strchr(" -_:", *spec) != NULL) {
+        spec++;
+    }
+    if (type == EVP_PKEY_RSA) { /* take spec as RSA key length */
+        nbits = UTIL_atoint(spec);
+        if (nbits < 1024 || 8192 < nbits)
+        {
+            LOG(FL_ERR, "bad RSA key length specification '%.40s'; must be integer between 1024 and 8192", spec);
+            return NULL;
+        }
+    } else if (type == EVP_PKEY_EC) { /* take spec as ECC curve name */
+        if (strcmp(spec, "secp192r1") == 0) {
+            LOG(FL_INFO, "using EC curve name prime192v1 instead of secp192r1");
+            nid = NID_X9_62_prime192v1;
+        } else if(strcmp(spec, "secp256r1") == 0) {
+            LOG(FL_INFO, "using EC curve name prime256v1 instead of secp256r1");
+            nid = NID_X9_62_prime256v1;
+        } else {
+            nid = OBJ_sn2nid(spec);
+        }
+        if (nid == 0) {
+            nid = EC_curve_nist2nid(spec);
+        }
+        if (nid == 0)
+        {
+            LOG(FL_ERR, "unknown EC curve name %.40s", spec);
+            return NULL;
+        }
+    }
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    (void)name;
     BIGNUM* bn = 0;
     RSA* rsa_key = 0;
-    EVP_PKEY* pkey = EVP_PKEY_new();
+    pkey = EVP_PKEY_new();
     if(0 is_eq pkey)
     {
         goto oom;
     }
 
-    int type = EVP_PKEY_NONE;
-    const char* const RSA_STR = "RSA";
-    const char* const EC_STR = "EC";
-    if(0 is_eq strncasecmp(spec, RSA_STR, strlen(RSA_STR)))
-    {
-        spec += strlen(RSA_STR);
-        type = EVP_PKEY_RSA;
-    }
-    else if(0 is_eq strncasecmp(spec, EC_STR, strlen(EC_STR)))
-    {
-        spec += strlen(EC_STR);
-        type = EVP_PKEY_EC;
-    }
-    if(type is_eq EVP_PKEY_NONE)
-    {
-        type = ('0' <= spec[0] and spec[0] <= '9') ? EVP_PKEY_RSA : EVP_PKEY_EC;
-    }
-    else
-    {
-        if(strchr(" -_:", spec[0]) not_eq 0)
-        {
-            spec++;
-        }
-    }
-
-    if(type is_eq EVP_PKEY_RSA)
-    { /* take spec as RSA key length */
-        int nbits = UTIL_atoint(spec);
-        if(nbits < 1024 or 8192 < nbits)
-        {
-            LOG(FL_ERR, "bad RSA key length specification '%.40s'; must be integer between 1024 and 8192", spec);
-            goto err;
-        }
-
+    if (type == EVP_PKEY_RSA) {
         bn = BN_new();
         rsa_key = RSA_new();
         if(0 is_eq bn or 0 is_eq rsa_key)
@@ -96,32 +147,7 @@ EVP_PKEY* KEY_new(const char* spec)
         goto end;
     }
     else
-    { /* take spec as ECC curve name */
-        int nid = 0;
-        if(0 is_eq strcmp(spec, "secp192r1"))
-        {
-            LOG(FL_INFO, "using EC curve name prime192v1 instead of secp192r1");
-            nid = NID_X9_62_prime192v1;
-        }
-        else if(0 is_eq strcmp(spec, "secp256r1"))
-        {
-            LOG(FL_INFO, "using EC curve name prime256v1 instead of secp256r1");
-            nid = NID_X9_62_prime256v1;
-        }
-        else
-        {
-            nid = OBJ_sn2nid(spec);
-        }
-        if(nid is_eq 0)
-        {
-            nid = EC_curve_nist2nid(spec);
-        }
-        if(0 is_eq nid)
-        {
-            LOG(FL_ERR, "unknown EC curve name '%.40s'", spec);
-            goto err;
-        }
-
+    { /* take spec as ECC curve name, even if no "EC:" prefix given */
         EC_KEY* ec_key = EC_KEY_new_by_curve_name(nid);
         if(0 is_eq ec_key)
         {
@@ -160,51 +186,47 @@ EVP_PKEY* KEY_new(const char* spec)
     BN_free(bn);
     return pkey;
 
-#else /* OPENSSL_VERSION_NUMBER < 0x10100000L */
-
-    EVP_PKEY* pkey = 0;
-    int type = EVP_PKEY_NONE;
-    const char* const RSA_STR = "RSA";
-    const char* const EC_STR = "EC";
-    if(0 is_eq strncasecmp(spec, RSA_STR, strlen(RSA_STR)))
-    {
-        spec += strlen(RSA_STR);
-        type = EVP_PKEY_RSA;
+#elif OPENSSL_VERSION_NUMBER >= OPENSSL_V_3_0_0
+    EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new_from_name(libctx, name, propq);
+    if (ctx == NULL) {
+        LOG(FL_ERR, "failed to create key generation context for %.40s (propq=%.100s); algorithm may be unknown or required provider may be unavailable",
+            name, propq != NULL ? propq : "(null)");
+        goto end;
     }
-    else if(0 is_eq strncasecmp(spec, EC_STR, strlen(EC_STR)))
-    {
-        spec += strlen(EC_STR);
-        type = EVP_PKEY_EC;
-    }
-    if(type is_eq EVP_PKEY_NONE)
-    {
-        type = ('0' <= spec[0] and spec[0] <= '9') ? EVP_PKEY_RSA : EVP_PKEY_EC;
-    }
-    else
-    {
-        if(strchr(" -_:", spec[0]) not_eq 0)
-        {
-            spec++;
-        }
+    if (EVP_PKEY_keygen_init(ctx) <= 0) {
+        LOG(FL_ERR, "failed to prepare generating %.40s key pair (propq=%.100s)",
+            name, propq != NULL ? propq : "(null)");
+        goto end;
     }
 
-    if(type is_eq EVP_PKEY_RSA)
-    { /* take spec as RSA key length */
-        int nbits = UTIL_atoint(spec);
-        if(nbits < 1024 or 8192 < nbits)
-        {
-            LOG(FL_ERR, "bad RSA key length specification '%.40s'; must be integer between 1024 and 8192", spec);
-            goto err;
+    if (type == EVP_PKEY_RSA) {
+        if (EVP_PKEY_CTX_set_rsa_keygen_bits(ctx, nbits) <= 0) {
+            LOG(FL_ERR, "Failed to set %d RSA bits", nbits);
+            goto end;
         }
+    } else if (type == EVP_PKEY_EC) {
+        if (EVP_PKEY_CTX_set_ec_paramgen_curve_nid(ctx, nid) <= 0) {
+            LOG(FL_ERR, "Failed to set EC curve nid = %d for %.40s", nid, spec);
+            goto end;
+        }
+    } else {
+        /* With OpenSSL >= 3.5; attempting to use full name/spec by itself, which may be sufficient, e.g., "ML-DSA-65" */
+    }
 
-#if OPENSSL_VERSION_NUMBER >= OPENSSL_V_3_0_0
-        pkey = EVP_RSA_gen(nbits); // This may depend on the availability of a suitable OpenSSL provider.
-        if (pkey == NULL) {
-            LOG(FL_ERR, "cannot generate RSA key with length %d", nbits);
-            goto err;
-        }
-        return pkey;
-#else
+    if (EVP_PKEY_keygen(ctx, &pkey) <= 0) {
+        LOG(FL_ERR, "failed generating %.40s key pair", name);
+        pkey = NULL;
+    }
+
+ end:
+    EVP_PKEY_CTX_free(ctx);
+    if (pkey == NULL)
+        (void)ERR_print_errors(bio_err);
+    return pkey;
+
+#else /* 0x10100000L <= OPENSSL_VERSION_NUMBER < OPENSSL_V_3_0_0 */
+    (void)name;
+    if (type == EVP_PKEY_RSA) {
         BIGNUM* bn = BN_new();
         RSA* rsa_key = RSA_new();
         pkey = EVP_PKEY_new();
@@ -233,43 +255,7 @@ EVP_PKEY* KEY_new(const char* spec)
         RSA_free(rsa_key);
         BN_free(bn);
         goto err;
-#endif
-    }
-    else
-    { /* take spec as ECC curve name */
-        int nid = 0;
-        if(0 is_eq strcmp(spec, "secp192r1"))
-        {
-            LOG(FL_INFO, "using EC curve name prime192v1 instead of secp192r1");
-            nid = NID_X9_62_prime192v1;
-        }
-        else if(0 is_eq strcmp(spec, "secp256r1"))
-        {
-            LOG(FL_INFO, "using EC curve name prime256v1 instead of secp256r1");
-            nid = NID_X9_62_prime256v1;
-        }
-        else
-        {
-            nid = OBJ_sn2nid(spec);
-        }
-        if(nid is_eq 0)
-        {
-            nid = EC_curve_nist2nid(spec);
-        }
-        if(0 is_eq nid)
-        {
-            LOG(FL_ERR, "unknown EC curve name %.40s", spec);
-            goto err;
-        }
-
-#if OPENSSL_VERSION_NUMBER >= OPENSSL_V_3_0_0
-        pkey = EVP_EC_gen(OSSL_EC_curve_nid2name(nid)); // This may depend on the availability of a suitable OpenSSL provider.
-        if (pkey == NULL) {
-            LOG(FL_ERR, "cannot generate EC key with curve name %.40s", spec);
-            goto err;
-        }
-        return pkey;
-#else
+    } else { /* taking spec as ECC curve name, even if no "EC:" prefix given */
         EC_KEY* ec_key = EC_KEY_new_by_curve_name(nid);
         if(0 is_eq ec_key)
         {
@@ -303,13 +289,12 @@ EVP_PKEY* KEY_new(const char* spec)
 
     ec_err:
         EC_KEY_free(ec_key);
-#endif
     }
 
  err:
     EVP_PKEY_free(pkey);
     (void)ERR_print_errors(bio_err);
-    return 0;
+    return NULL;
 #endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */
 }
 

--- a/src/libsecutils/src/credentials/store.c
+++ b/src/libsecutils/src/credentials/store.c
@@ -471,75 +471,69 @@ err:
 }
 
 
-bool STORE_set1_host_ip(X509_STORE* ts, OPTIONAL const char* name, OPTIONAL const char* ip)
+bool STORE_set1_host_ip(X509_STORE *ts, OPTIONAL const char *name, OPTIONAL const char *ip)
 {
-    if(ts is_eq 0)
-    {
+    if (ts == NULL) {
         LOG_err("null pointer argument");
         return false;
     }
-    X509_VERIFY_PARAM* ts_vpm = X509_STORE_get0_param(ts);
+    X509_VERIFY_PARAM *ts_vpm = X509_STORE_get0_param(ts);
 
     /* first clear any host names, IP addresses, and email addresses */
-    if(
-#if OPENSSL_VERSION_NUMBER < OPENSSL_V_3_0_0
-       not STORE_set1_host(ts, 0) or
-#endif
-       0 is_eq X509_VERIFY_PARAM_set1_host(ts_vpm, 0, 0) or
-       0 is_eq X509_VERIFY_PARAM_set1_ip(ts_vpm, 0, 0) or
-       0 is_eq X509_VERIFY_PARAM_set1_email(ts_vpm, 0, 0))
-    {
+    if (
+# if OPENSSL_VERSION_NUMBER < OPENSSL_V_3_0_0
+        !STORE_set1_host(ts, 0) ||
+# endif
+        !X509_VERIFY_PARAM_set1_host(ts_vpm, 0, 0)
+        || !X509_VERIFY_PARAM_set1_ip(ts_vpm, 0, 0)
+        || !X509_VERIFY_PARAM_set1_email(ts_vpm, 0, 0)) {
         LOG_err("Could not clear host names and IP and email addresses from store");
         return false;
     }
 
-    if(0 is_eq name and 0 is_eq ip)
-    {
+    if (name == NULL && ip == NULL)
         return true;
-    }
 
-    char* name_str = CONN_get_host(name);
-    if(name not_eq 0 and name_str is_eq 0)
-    {
+    char *name_str = CONN_get_host(name);
+    char *ip_str = NULL;
+    if (name != NULL && name_str == NULL)
         return false;
-    }
-
-    char* ip_str = CONN_get_host(ip);
-    if(ip not_eq 0 and ip_str is_eq 0)
-    {
-        OPENSSL_free(name_str);
-        return false;
+    if (name != NULL && ip != NULL && strcmp(name, ip) == 0) {
+        if (CONN_IS_IP_ADDR(name_str)) {
+            ip_str = name_str;
+            name = name_str = NULL;
+        } else {
+            ip = NULL;
+        }
+    } else {
+        ip_str = CONN_get_host(ip);
+        if (ip != NULL && ip_str == NULL) {
+            OPENSSL_free(name_str);
+            return false;
+        }
     }
 
     X509_VERIFY_PARAM_set_hostflags(ts_vpm,
                                     X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT |
                                     X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
     bool res = true;
-    if(ip_str not_eq 0 and X509_VERIFY_PARAM_set1_ip_asc(ts_vpm, ip_str) is_eq 0)
-    {
+    if (ip_str != NULL && !X509_VERIFY_PARAM_set1_ip_asc(ts_vpm, ip_str))
         res = false;
-    }
-    if(name_str not_eq 0 and (ip_str is_eq 0 or (res is_eq false and strcmp(name, ip) is_eq 0)))
-    {
-        res = X509_VERIFY_PARAM_set1_host(ts_vpm, name_str, 0) not_eq 0;
-#if OPENSSL_VERSION_NUMBER < OPENSSL_V_3_0_0
+    if (name_str != NULL) {
+        res = res && X509_VERIFY_PARAM_set1_host(ts_vpm, name_str, 0) != 0;
+# if OPENSSL_VERSION_NUMBER < OPENSSL_V_3_0_0
         /*
          * Before OpenSSL 3.0, there was no API function for retrieving the
-         * hostname/ip entries in X509_VERIFY_PARAM. So we store the host value
+         * hostname/ip entries in X509_VERIFY_PARAM. So we stored the host value
          * in ex_data for use in CREDENTIALS_print_cert_verify_cb().
          * Since OpenSSL 3.0, this is no more needed as X509_VERIFY_PARAM_get0_host() is available.
          */
-        if(res not_eq false)
-        {
-            res = STORE_set1_host(ts, name_str);
-        }
-#endif
+        res = res && STORE_set1_host(ts, name_str);
+# endif
     }
-    if(res is_eq false)
-    {
-        LOG(FL_ERR, "Could not set host name '%s' and/or IP address '%s' in store", name_str not_eq 0 ? name_str : "",
-            ip_str not_eq 0 ? ip_str : "");
-    }
+    if (!res)
+        LOG(FL_ERR, "Could not set host name '%s' and/or IP address '%s' in store",
+            name_str != NULL ? name_str : "", ip_str != NULL ? ip_str : "");
     OPENSSL_free(ip_str);
     OPENSSL_free(name_str);
     return res;

--- a/src/libsecutils/src/credentials/verify.c
+++ b/src/libsecutils/src/credentials/verify.c
@@ -50,6 +50,7 @@ int CREDENTIALS_print_cert_verify_cb(int ok, X509_STORE_CTX* store_ctx)
         bool nonfinal = (flags bitand X509_V_FLAG_NONFINAL_CHECK) not_eq 0;
         X509_STORE* ts = X509_STORE_CTX_get0_store(store_ctx);
         const char* expected = 0;
+        char *expected_to_free = NULL;
 
         /* Not yet valid certificates are OK */
         if(cert_error == X509_V_ERR_CERT_NOT_YET_VALID)
@@ -91,8 +92,14 @@ int CREDENTIALS_print_cert_verify_cb(int ok, X509_STORE_CTX* store_ctx)
             case X509_V_ERR_OCSP_CERT_UNKNOWN:
                 certstatus_error = true;
                 break;
-            case X509_V_ERR_HOSTNAME_MISMATCH:
             case X509_V_ERR_IP_ADDRESS_MISMATCH:
+#if OPENSSL_VERSION_NUMBER >= OPENSSL_V_3_0_0
+                expected = expected_to_free = X509_VERIFY_PARAM_get1_ip_asc(param);
+                break;
+#else
+                /* fall thru */
+#endif
+            case X509_V_ERR_HOSTNAME_MISMATCH:
                 expected = STORE_get0_host(ts);
                 break;
             case X509_V_ERR_INVALID_PURPOSE:
@@ -109,7 +116,7 @@ int CREDENTIALS_print_cert_verify_cb(int ok, X509_STORE_CTX* store_ctx)
            and false is_eq STORE_CTX_tls_active(store_ctx) /* ssl_add_cert_chain() or check_cert_revocation() is active */
            and not certstatus_error and not checking_ocsp)
         {
-            return ok; /* avoid printing spurious errors */
+            goto end; /* avoid printing spurious errors */
         }
 #endif
 
@@ -171,6 +178,8 @@ int CREDENTIALS_print_cert_verify_cb(int ok, X509_STORE_CTX* store_ctx)
                 }
             }
         }
+    end:
+        OPENSSL_free(expected_to_free);
     }
     return ok;
 }

--- a/src/libsecutils/src/storage/files.c
+++ b/src/libsecutils/src/storage/files.c
@@ -32,7 +32,7 @@ _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
 #include <certstatus/crls.h>
 #include <credentials/cert.h>
 #include <util/log.h>
-# include <connections/conn.h>
+#include <connections/conn.h>
 
 #include <operators.h>
 
@@ -42,8 +42,7 @@ static file_format_t adjust_format(const char* * file, file_format_t format, boo
     (void)engine_ok; /* unused parameter */
 #endif
 
-    if(strncasecmp(*file, CONN_http_prefix, strlen(CONN_http_prefix)) is_eq 0 or
-       strncasecmp(*file, CONN_https_prefix, strlen(CONN_https_prefix)) is_eq 0)
+    if (CONN_IS_HTTP(*file) || CONN_IS_HTTPS(*file))
     {
         format = FORMAT_HTTP;
     }


### PR DESCRIPTION
This adds 
`EVP_PKEY *KEY_new_ex(const char *spec, OPTIONAL OSSL_LIB_CTX *libctx, OPTIONAL const char *propq)`
and defines `KEY_new(spec)` as `KEY_new_ex(spec, NULL, NULL)` for backward compatibility.

~For OpenSSL 3.0+, a location of the form "tpm2:handle=0x<hex-string>" can be used for key generation within the tpm2-openssl provider.~
For OpenSSL 3.5+, the `spec` parameter may now be a PQC algorithm name (and level), e.g.., `"ML-DSA-65"`. 

On this, occasion, due to Copilot review comment on `credentials.c`,
also fix `find_update_cb()` crash on NULL tag/description strings.

Moreover:
* for OpenSSL 4.0 compatibility, fix constness in `cdp_util.{c,h}` and `crl_mgmt.c`
* improve `STORE_set1_host_ip()` behavior on equal 'name' and 'ip' argument
* `CREDENTIALS_print_cert_verify_cb()`: fix output of expected IP address on mismatch
* improve `CONN_IS_HTTP(S)` and use it to replace respective occurrences of `strncasecmp()`
* `conn.c,util.h`: add `UTIL_SKIP_SCHEME()` and improve `skip_scheme()` using it
* `basic.h`: fix compatibility with C23, which provides `true` and `false` as keywords (also covered meanwhile by #74)
