### PR TITLE
`CMakeLists.txt`,`Makefile_v1`,`debian/`: advance to version 2.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.18)
 
 project(
   security-utilities
-  VERSION 2.1.0 # always 3 components for correct versioning
+  VERSION 2.2.0 # always 3 components for correct versioning
   LANGUAGES C)
 message(STATUS "SecurityUtilities version ${security-utilities_VERSION}")
 

--- a/Makefile_v1
+++ b/Makefile_v1
@@ -33,7 +33,7 @@ ifeq ($(OUT_DIR),)
      override OUT_DIR = .
 endif
 
-VERSION=2.1
+VERSION=2.2
 # must be kept in sync with debian/changelog and CMakeLists.txt
 # PACKAGENAME=libsecutils
 # DIRNAME=$(PACKAGENAME)-$(VERSION)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libsecutils (2.2) stable; urgency=medium
+
+  * add UTIL_cmp_timeframe() and CRL_check() for support of upcoming OpenSSL 4.0
+
+ -- David von Oheimb <David.von.Oheimb@siemens.com>  Fri, 20 Feb 2026 12:40:40 +0100
+
 libsecutils (2.1) stable; urgency=medium
 
   * Various fixes on build system, code, and OpenSSL version compatibility

--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,7 @@ Description: OpenSSL enhancement wrapper library
  With extended support for certficate status checking using CRLs and/or OCSP
 
 Package: libsecutils-dev
-Depends: libsecutils (>= 2.1), ${misc:Depends}
+Depends: libsecutils (>= 2.2), ${misc:Depends}
 Suggests: libssl-dev, libuta-dev
 Section: devel
 Architecture: all


### PR DESCRIPTION
I forgot to bump to v2.2, which should be done for consistency with genCMPClient v2.2.